### PR TITLE
feat: consolidate per-language-set phrase tables into one table

### DIFF
--- a/backend/alembic/versions/b2f1c0d4e5a6_consolidate_phrases_single_table.py
+++ b/backend/alembic/versions/b2f1c0d4e5a6_consolidate_phrases_single_table.py
@@ -1,0 +1,96 @@
+"""Consolidate per-language-set phrase tables into a single phrases table.
+
+Creates a single `phrases` table keyed by language_set_id, copies rows from every
+legacy dynamic `phrases_<name>` table, and remaps the phrase_id references stored in
+`user_private_list_phrases` and `teacher_phrase_set_phrases` (which pointed at the
+per-set tables' local ids) to the new global ids.
+
+The old `phrases_<name>` tables are intentionally left in place as a backup; a follow-up
+migration can drop them once this is verified in production.
+
+Revision ID: b2f1c0d4e5a6
+Revises: fae66ffa8bec
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2f1c0d4e5a6"
+down_revision: Union[str, Sequence[str], None] = "fae66ffa8bec"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _legacy_table_name(language_set_name: str) -> str:
+    """Replicate the old dynamic table naming exactly."""
+    safe = language_set_name.replace("-", "_").replace(" ", "_").lower()
+    return f"phrases_{safe}"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "phrases",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "language_set_id",
+            sa.Integer(),
+            sa.ForeignKey("language_sets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("categories", sa.String(), nullable=False),
+        sa.Column("phrase", sa.String(), nullable=False),
+        sa.Column("translation", sa.Text(), nullable=False),
+    )
+    op.create_index("ix_phrases_language_set_id", "phrases", ["language_set_id"])
+    op.create_index("idx_phrases_set_id", "phrases", ["language_set_id", "id"])
+
+    bind = op.get_bind()
+
+    language_sets = bind.execute(sa.text("SELECT id, name FROM language_sets")).fetchall()
+
+    # (language_set_id, old_phrase_id) -> new global phrase id
+    id_map: dict[tuple[int, int], int] = {}
+
+    for set_id, set_name in language_sets:
+        legacy = _legacy_table_name(set_name)
+        exists = bind.execute(sa.text("SELECT to_regclass(:t)"), {"t": f"public.{legacy}"}).scalar()
+        if not exists:
+            continue
+
+        rows = bind.execute(
+            sa.text(f'SELECT id, categories, phrase, translation FROM "{legacy}" ORDER BY id')
+        ).fetchall()
+
+        for old_id, categories, phrase, translation in rows:
+            new_id = bind.execute(
+                sa.text(
+                    "INSERT INTO phrases (language_set_id, categories, phrase, translation) "
+                    "VALUES (:ls, :c, :p, :t) RETURNING id"
+                ),
+                {"ls": set_id, "c": categories, "p": phrase, "t": translation},
+            ).scalar()
+            id_map[(set_id, old_id)] = new_id
+
+    # Remap phrase_id references in the junction tables.
+    for table in ("user_private_list_phrases", "teacher_phrase_set_phrases"):
+        refs = bind.execute(
+            sa.text(f"SELECT id, language_set_id, phrase_id FROM {table} WHERE phrase_id IS NOT NULL")
+        ).fetchall()
+        for row_id, ls_id, old_phrase_id in refs:
+            new_id = id_map.get((ls_id, old_phrase_id))
+            if new_id is not None:
+                bind.execute(
+                    sa.text(f"UPDATE {table} SET phrase_id = :new WHERE id = :rid"),
+                    {"new": new_id, "rid": row_id},
+                )
+
+
+def downgrade() -> None:
+    # The legacy phrases_<name> tables were left intact by upgrade(), so the data still
+    # lives there; simply drop the consolidated table. (Junction phrase_id values are not
+    # reverted — restore from backup if a full rollback is required.)
+    op.drop_index("idx_phrases_set_id", table_name="phrases")
+    op.drop_index("ix_phrases_language_set_id", table_name="phrases")
+    op.drop_table("phrases")

--- a/backend/osmosmjerka/database/base.py
+++ b/backend/osmosmjerka/database/base.py
@@ -8,9 +8,9 @@ from typing import Any, Optional
 
 from databases import Database
 from dotenv import load_dotenv
-from osmosmjerka.database.models import create_phrase_table, metadata
+from osmosmjerka.database.models import metadata
 from osmosmjerka.logging_config import get_logger
-from sqlalchemy import Table, create_engine, text
+from sqlalchemy import create_engine
 
 # Load environment variables
 load_dotenv()
@@ -25,7 +25,6 @@ class BaseDatabaseManager:
         self._database_url = database_url
         self.database = None
         self.engine = None
-        self._phrase_tables_cache = {}  # Cache for dynamically created phrase tables
         self._statistics_cache = {}  # Cache for user statistics with TTL
         self._statistics_cache_ttl = 300  # 5 minutes cache TTL
 
@@ -146,44 +145,3 @@ class BaseDatabaseManager:
         except Exception as exc:
             logger.exception("Failed to initialise database schema", extra={"error": str(exc)})
             raise
-
-    def _get_phrase_table_name(self, language_set_name: str) -> str:
-        """Get the table name for a language set's phrases using the set's short name."""
-        # Sanitize the name to ensure it's safe for SQL table names
-        safe_name = language_set_name.replace("-", "_").replace(" ", "_").lower()
-        return f"phrases_{safe_name}"
-
-    def _get_phrase_table(self, language_set_name: str) -> Table:
-        """Get or create a phrase table for a specific language set."""
-        table_name = self._get_phrase_table_name(language_set_name)
-
-        # Check cache first
-        if table_name in self._phrase_tables_cache:
-            return self._phrase_tables_cache[table_name]
-
-        # Create new table object
-        phrase_table = create_phrase_table(table_name)
-        self._phrase_tables_cache[table_name] = phrase_table
-
-        # Create the actual table in database if it doesn't exist
-        if self.engine:
-            phrase_table.create(bind=self.engine, checkfirst=True)
-
-        return phrase_table
-
-    async def _ensure_phrase_table_exists(self, language_set_name: str) -> None:
-        """Ensure phrase table exists for the given language set."""
-        table_name = self._get_phrase_table_name(language_set_name)
-        database = self._ensure_database()
-
-        # Check if table exists
-        result = await database.fetch_one(
-            text("SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = :table_name)"),
-            {"table_name": table_name},
-        )
-
-        if not (result and result[0]):
-            # Table doesn't exist, create it
-            phrase_table = self._get_phrase_table(language_set_name)
-            if self.engine:
-                phrase_table.create(bind=self.engine, checkfirst=True)

--- a/backend/osmosmjerka/database/language_sets.py
+++ b/backend/osmosmjerka/database/language_sets.py
@@ -63,9 +63,8 @@ class LanguageSetsMixin:
         )
         language_set_id = await database.execute(query)
 
-        # Create the phrase table for this language set
-        await self._ensure_phrase_table_exists(name)
-
+        # Phrases live in the shared `phrases` table keyed by language_set_id;
+        # no per-set table needs to be created.
         return language_set_id
 
     async def update_language_set(self, language_set_id: int, **updates) -> int:
@@ -97,20 +96,12 @@ class LanguageSetsMixin:
         """Delete a language set and its phrase table."""
         database = self._ensure_database()
 
-        # First get the language set to find its name
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             return
 
-        # Drop the phrase table
-        table_name = self._get_phrase_table_name(language_set["name"])
-        await database.execute(f"DROP TABLE IF EXISTS {table_name}")
-
-        # Remove from cache
-        if table_name in self._phrase_tables_cache:
-            del self._phrase_tables_cache[table_name]
-
-        # Delete the language set
+        # Deleting the language set cascades to its phrases (phrases.language_set_id
+        # has ON DELETE CASCADE).
         await database.execute(delete(language_sets_table).where(language_sets_table.c.id == language_set_id))
 
     async def set_default_language_set(self, language_set_id: int):

--- a/backend/osmosmjerka/database/models.py
+++ b/backend/osmosmjerka/database/models.py
@@ -36,18 +36,24 @@ language_sets_table = Table(
 )
 
 
-# Dynamic phrase table creation function
-def create_phrase_table(table_name: str) -> Table:
-    """Create a phrases table for a specific language set"""
-    return Table(
-        table_name,
-        metadata,
-        Column("id", Integer, primary_key=True, index=True),
-        Column("categories", String, nullable=False),
-        Column("phrase", String, nullable=False),
-        Column("translation", Text, nullable=False),
-        extend_existing=True,
-    )
+# Single phrases table for all language sets, keyed by language_set_id.
+# (Replaced the previous per-language-set dynamic tables `phrases_<name>`.)
+phrases_table = Table(
+    "phrases",
+    metadata,
+    Column("id", Integer, primary_key=True, index=True),
+    Column(
+        "language_set_id",
+        Integer,
+        ForeignKey("language_sets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("categories", String, nullable=False),
+    Column("phrase", String, nullable=False),
+    Column("translation", Text, nullable=False),
+    Index("idx_phrases_set_id", "language_set_id", "id"),
+)
 
 
 # Define the accounts table for user management

--- a/backend/osmosmjerka/database/phrases.py
+++ b/backend/osmosmjerka/database/phrases.py
@@ -2,13 +2,26 @@
 
 from typing import Optional
 
-from osmosmjerka.database.models import language_sets_table
+from osmosmjerka.database.models import language_sets_table, phrases_table
 from sqlalchemy import func
 from sqlalchemy.sql import delete, insert, select, update
 
 
 class PhrasesMixin:
-    """Mixin class providing phrase management methods."""
+    """Mixin class providing phrase management methods.
+
+    All phrases live in the single `phrases` table keyed by `language_set_id`.
+    """
+
+    async def _resolve_language_set(self, language_set_id: Optional[int]):
+        """Resolve a language set by id, or fall back to the first active one.
+
+        Returns the language set dict, or None if none is available.
+        """
+        if language_set_id is None:
+            sets = await self.get_language_sets(active_only=True)
+            return sets[0] if sets else None
+        return await self.get_language_set_by_id(language_set_id)
 
     async def get_phrases(
         self,
@@ -18,27 +31,17 @@ class PhrasesMixin:
         offset: int = 0,
         ignored_categories_override: Optional[set[str]] = None,
     ) -> list[dict[str, str]]:
-        """Get phrases from specified language set using dynamic table."""
+        """Get phrases from a language set (applies ignored-category filtering)."""
         database = self._ensure_database()
 
-        # If no language set specified, use the first active one
-        if language_set_id is None:
-            sets = await self.get_language_sets(active_only=True)
-            if not sets:
-                return []
-            language_set = sets[0]
-        else:
-            language_set = await self.get_language_set_by_id(language_set_id)
-            if not language_set:
-                return []
+        language_set = await self._resolve_language_set(language_set_id)
+        if not language_set:
+            return []
 
-        # Get the dynamic phrase table
-        phrase_table = self._get_phrase_table(language_set["name"])
-
-        query = select(phrase_table)
+        query = select(phrases_table).where(phrases_table.c.language_set_id == language_set["id"])
         if category:
-            query = query.where(phrase_table.c.categories.like(f"%{category}%"))
-        query = query.order_by(phrase_table.c.id)
+            query = query.where(phrases_table.c.categories.like(f"%{category}%"))
+        query = query.order_by(phrases_table.c.id)
         if limit:
             query = query.limit(limit).offset(offset)
 
@@ -54,6 +57,7 @@ class PhrasesMixin:
 
         for row in result:
             row = dict(row)
+            row.pop("language_set_id", None)
             # Skip phrases shorter than 3 characters
             if len(str(row["phrase"]).strip()) < 3:
                 continue
@@ -68,34 +72,29 @@ class PhrasesMixin:
         return row_list
 
     async def add_phrase(self, language_set_id: int, categories: str, phrase: str, translation: str):
-        """Add a new phrase to a language set using dynamic table."""
+        """Add a new phrase to a language set."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        # Ensure phrase table exists and get it
-        await self._ensure_phrase_table_exists(language_set["name"])
-        phrase_table = self._get_phrase_table(language_set["name"])
-
-        query = insert(phrase_table).values(categories=categories, phrase=phrase, translation=translation)
+        query = insert(phrases_table).values(
+            language_set_id=language_set_id, categories=categories, phrase=phrase, translation=translation
+        )
         return await database.execute(query)
 
     async def update_phrase(self, phrase_id: int, language_set_id: int, categories: str, phrase: str, translation: str):
-        """Update an existing phrase using dynamic table."""
+        """Update an existing phrase."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
         query = (
-            update(phrase_table)
-            .where(phrase_table.c.id == phrase_id)
+            update(phrases_table)
+            .where(phrases_table.c.id == phrase_id, phrases_table.c.language_set_id == language_set_id)
             .values(categories=categories, phrase=phrase, translation=translation)
         )
         return await database.execute(query)
@@ -104,70 +103,76 @@ class PhrasesMixin:
         """Get specific phrases by their IDs."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = select(phrase_table).where(phrase_table.c.id.in_(phrase_ids))
+        query = select(phrases_table).where(
+            phrases_table.c.language_set_id == language_set_id, phrases_table.c.id.in_(phrase_ids)
+        )
         result = await database.fetch_all(query)
-        return [dict(row) for row in result]
+        rows = []
+        for row in result:
+            row = dict(row)
+            row.pop("language_set_id", None)
+            rows.append(row)
+        return rows
 
     async def update_phrase_categories(self, phrase_id: int, categories: str, language_set_id: int):
         """Update only the categories of a specific phrase."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = update(phrase_table).where(phrase_table.c.id == phrase_id).values(categories=categories)
+        query = (
+            update(phrases_table)
+            .where(phrases_table.c.id == phrase_id, phrases_table.c.language_set_id == language_set_id)
+            .values(categories=categories)
+        )
         return await database.execute(query)
 
     async def delete_phrase(self, phrase_id: int, language_set_id: int):
-        """Delete a phrase using dynamic table."""
+        """Delete a phrase."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = delete(phrase_table).where(phrase_table.c.id == phrase_id)
+        query = delete(phrases_table).where(
+            phrases_table.c.id == phrase_id, phrases_table.c.language_set_id == language_set_id
+        )
         return await database.execute(query)
 
     async def batch_delete_phrases(self, phrase_ids: list[int], language_set_id: int) -> int:
-        """Delete multiple phrases using dynamic table."""
+        """Delete multiple phrases."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = delete(phrase_table).where(phrase_table.c.id.in_(phrase_ids))
+        query = delete(phrases_table).where(
+            phrases_table.c.language_set_id == language_set_id, phrases_table.c.id.in_(phrase_ids)
+        )
         result = await database.execute(query)
         # Return the number of deleted rows or the length of phrase_ids if result is None
         return getattr(result, "rowcount", len(phrase_ids)) if result else len(phrase_ids)
 
     async def batch_add_category(self, phrase_ids: list[int], category: str, language_set_id: int) -> int:
-        """Add a category to multiple phrases using dynamic table."""
+        """Add a category to multiple phrases."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-
         # Get current phrases that need updating
-        select_query = select(phrase_table.c.id, phrase_table.c.categories).where(phrase_table.c.id.in_(phrase_ids))
+        select_query = select(phrases_table.c.id, phrases_table.c.categories).where(
+            phrases_table.c.language_set_id == language_set_id, phrases_table.c.id.in_(phrase_ids)
+        )
         phrases = await database.fetch_all(select_query)
 
         affected_count = 0
@@ -179,7 +184,7 @@ class PhrasesMixin:
             if category not in current_cat_list:
                 new_categories = " ".join(current_cat_list + [category])
                 update_query = (
-                    update(phrase_table).where(phrase_table.c.id == phrase["id"]).values(categories=new_categories)
+                    update(phrases_table).where(phrases_table.c.id == phrase["id"]).values(categories=new_categories)
                 )
                 await database.execute(update_query)
                 affected_count += 1
@@ -187,18 +192,17 @@ class PhrasesMixin:
         return affected_count
 
     async def batch_remove_category(self, phrase_ids: list[int], category: str, language_set_id: int) -> int:
-        """Remove a category from multiple phrases using dynamic table."""
+        """Remove a category from multiple phrases."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-
         # Get current phrases that need updating
-        select_query = select(phrase_table.c.id, phrase_table.c.categories).where(phrase_table.c.id.in_(phrase_ids))
+        select_query = select(phrases_table.c.id, phrases_table.c.categories).where(
+            phrases_table.c.language_set_id == language_set_id, phrases_table.c.id.in_(phrase_ids)
+        )
         phrases = await database.fetch_all(select_query)
 
         affected_count = 0
@@ -211,7 +215,7 @@ class PhrasesMixin:
                 new_cat_list = [cat for cat in current_cat_list if cat != category]
                 new_categories = " ".join(new_cat_list)
                 update_query = (
-                    update(phrase_table).where(phrase_table.c.id == phrase["id"]).values(categories=new_categories)
+                    update(phrases_table).where(phrases_table.c.id == phrase["id"]).values(categories=new_categories)
                 )
                 await database.execute(update_query)
                 affected_count += 1
@@ -221,21 +225,14 @@ class PhrasesMixin:
     async def get_categories_for_language_set(
         self, language_set_id: Optional[int] = None, ignored_categories_override: Optional[set[str]] = None
     ) -> list[str]:
-        """Get categories for a specific language set using dynamic table."""
+        """Get categories for a specific language set (applies ignored filtering)."""
         database = self._ensure_database()
 
-        if language_set_id is None:
-            sets = await self.get_language_sets(active_only=True)
-            if not sets:
-                return []
-            language_set = sets[0]
-        else:
-            language_set = await self.get_language_set_by_id(language_set_id)
-            if not language_set:
-                return []
+        language_set = await self._resolve_language_set(language_set_id)
+        if not language_set:
+            return []
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = select(phrase_table.c.categories)
+        query = select(phrases_table.c.categories).where(phrases_table.c.language_set_id == language_set["id"])
         result = await database.fetch_all(query)
         categories_set = set()
 
@@ -260,22 +257,18 @@ class PhrasesMixin:
         """
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             raise ValueError(f"Language set with ID {language_set_id} not found")
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-
         # Find phrases with duplicate text (case-insensitive)
-        # First, get all phrases with their lowercase phrase text for comparison
         query = select(
-            phrase_table.c.id,
-            phrase_table.c.categories,
-            phrase_table.c.phrase,
-            phrase_table.c.translation,
-            func.lower(phrase_table.c.phrase).label("phrase_lower"),
-        )
+            phrases_table.c.id,
+            phrases_table.c.categories,
+            phrases_table.c.phrase,
+            phrases_table.c.translation,
+            func.lower(phrases_table.c.phrase).label("phrase_lower"),
+        ).where(phrases_table.c.language_set_id == language_set_id)
 
         all_phrases = await database.fetch_all(query)
 
@@ -320,33 +313,25 @@ class PhrasesMixin:
         offset: int = 0,
         search_term: Optional[str] = None,
     ) -> list[dict[str, str]]:
-        """Get phrases for admin panel using dynamic table - returns all phrases including ignored categories."""
+        """Get phrases for admin panel - returns all phrases including ignored categories."""
         database = self._ensure_database()
 
-        # If no language set specified, use the first active one
-        if language_set_id is None:
-            sets = await self.get_language_sets(active_only=True)
-            if not sets:
-                return []
-            language_set = sets[0]
-        else:
-            language_set = await self.get_language_set_by_id(language_set_id)
-            if not language_set:
-                return []
+        language_set = await self._resolve_language_set(language_set_id)
+        if not language_set:
+            return []
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = select(phrase_table)
+        query = select(phrases_table).where(phrases_table.c.language_set_id == language_set["id"])
         if category:
-            query = query.where(phrase_table.c.categories.like(f"%{category}%"))
+            query = query.where(phrases_table.c.categories.like(f"%{category}%"))
         if search_term:
             # Search in phrase, translation, and categories fields
             search_filter = (
-                phrase_table.c.phrase.ilike(f"%{search_term}%")
-                | phrase_table.c.translation.ilike(f"%{search_term}%")
-                | phrase_table.c.categories.ilike(f"%{search_term}%")
+                phrases_table.c.phrase.ilike(f"%{search_term}%")
+                | phrases_table.c.translation.ilike(f"%{search_term}%")
+                | phrases_table.c.categories.ilike(f"%{search_term}%")
             )
             query = query.where(search_filter)
-        query = query.order_by(phrase_table.c.id)
+        query = query.order_by(phrases_table.c.id)
         if limit:
             query = query.limit(limit).offset(offset)
 
@@ -354,6 +339,7 @@ class PhrasesMixin:
         row_list = []
         for row in result:
             row = dict(row)
+            row.pop("language_set_id", None)
             # Only skip phrases shorter than 3 characters - NO category filtering
             if len(str(row["phrase"]).strip()) < 3:
                 continue
@@ -363,53 +349,38 @@ class PhrasesMixin:
     async def get_phrase_count_for_admin(
         self, language_set_id: Optional[int] = None, category: Optional[str] = None, search_term: Optional[str] = None
     ) -> int:
-        """Get phrase count for admin panel using dynamic table - counts all phrases including ignored categories."""
+        """Get phrase count for admin panel - counts all phrases including ignored categories."""
         database = self._ensure_database()
 
-        # If no language set specified, use the first active one
-        if language_set_id is None:
-            sets = await self.get_language_sets(active_only=True)
-            if not sets:
-                return 0
-            language_set = sets[0]
-        else:
-            language_set = await self.get_language_set_by_id(language_set_id)
-            if not language_set:
-                return 0
+        language_set = await self._resolve_language_set(language_set_id)
+        if not language_set:
+            return 0
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = select(func.count(phrase_table.c.id))
+        query = select(func.count(phrases_table.c.id)).where(phrases_table.c.language_set_id == language_set["id"])
         if category:
-            query = query.where(phrase_table.c.categories.like(f"%{category}%"))
+            query = query.where(phrases_table.c.categories.like(f"%{category}%"))
         if search_term:
             # Search in phrase, translation, and categories fields
             search_filter = (
-                phrase_table.c.phrase.ilike(f"%{search_term}%")
-                | phrase_table.c.translation.ilike(f"%{search_term}%")
-                | phrase_table.c.categories.ilike(f"%{search_term}%")
+                phrases_table.c.phrase.ilike(f"%{search_term}%")
+                | phrases_table.c.translation.ilike(f"%{search_term}%")
+                | phrases_table.c.categories.ilike(f"%{search_term}%")
             )
             query = query.where(search_filter)
         # Only filter by minimum phrase length - NO category filtering
-        query = query.where(func.length(phrase_table.c.phrase) >= 3)
+        query = query.where(func.length(phrases_table.c.phrase) >= 3)
         result = await database.fetch_one(query)
         return int(result[0]) if result and result[0] is not None else 0
 
     async def get_all_categories_for_language_set(self, language_set_id: Optional[int] = None) -> list[str]:
-        """Get all categories including ignored ones for a language set using dynamic table - used for admin panel."""
+        """Get all categories including ignored ones for a language set - used for admin panel."""
         database = self._ensure_database()
 
-        if language_set_id is None:
-            sets = await self.get_language_sets(active_only=True)
-            if not sets:
-                return []
-            language_set = sets[0]
-        else:
-            language_set = await self.get_language_set_by_id(language_set_id)
-            if not language_set:
-                return []
+        language_set = await self._resolve_language_set(language_set_id)
+        if not language_set:
+            return []
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = select(phrase_table.c.categories)
+        query = select(phrases_table.c.categories).where(phrases_table.c.language_set_id == language_set["id"])
         result = await database.fetch_all(query)
         categories_set = set()
         for row in result:
@@ -419,15 +390,12 @@ class PhrasesMixin:
         return sorted(list(categories_set))
 
     def fast_bulk_insert_phrases(self, language_set_id: int, phrases_data):
-        """Bulk insert phrases for a language set using dynamic table for performance."""
+        """Bulk insert phrases for a language set (synchronous, for performance)."""
         if not phrases_data:
             return 0
 
-        # Get language set info
         engine = self._ensure_engine()
 
-        # We need to get the language set synchronously for the table name
-        # This is a limitation of the bulk insert approach
         with engine.connect() as conn:
             result = conn.execute(
                 select(language_sets_table).where(language_sets_table.c.id == language_set_id)
@@ -435,22 +403,18 @@ class PhrasesMixin:
             if not result:
                 raise ValueError(f"Language set with ID {language_set_id} not found")
 
-            language_set = dict(result._mapping)
-            phrase_table = self._get_phrase_table(language_set["name"])
-
-            result = conn.execute(insert(phrase_table), phrases_data)
+            rows = [{**dict(row), "language_set_id": language_set_id} for row in phrases_data]
+            result = conn.execute(insert(phrases_table), rows)
             conn.commit()
             return result.rowcount
 
     async def clear_all_phrases(self, language_set_id: int):
-        """Clear all phrases for a specific language set using dynamic table."""
+        """Clear all phrases for a specific language set."""
         database = self._ensure_database()
 
-        # Get language set info
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             return
 
-        phrase_table = self._get_phrase_table(language_set["name"])
-        query = delete(phrase_table)
+        query = delete(phrases_table).where(phrases_table.c.language_set_id == language_set_id)
         await database.execute(query)

--- a/backend/osmosmjerka/database/private_lists.py
+++ b/backend/osmosmjerka/database/private_lists.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from osmosmjerka.database.models import (
     accounts_table,
+    phrases_table,
     user_private_list_phrases_table,
     user_private_lists_table,
 )
@@ -252,7 +253,9 @@ class PrivateListsMixin:
         if not language_set:
             return {"entries": [], "total": 0, "limit": limit, "offset": offset, "has_more": False}
 
-        phrase_table = self._get_phrase_table(language_set["name"])
+        # Phrase ids are globally unique in the single phrases table, so joining on
+        # id alone resolves to the correct language set's row.
+        phrase_table = phrases_table
 
         # Base query for counting
         base_query = (

--- a/backend/osmosmjerka/database/teacher_access.py
+++ b/backend/osmosmjerka/database/teacher_access.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from osmosmjerka.database.models import (
     accounts_table,
+    phrases_table,
     teacher_group_members_table,
     teacher_phrase_set_access_table,
     teacher_phrase_set_groups_table,
@@ -298,12 +299,12 @@ class TeacherSetsAccessMixin:
         if not language_set_id:
             return []
 
-        # Get language set name
         language_set = await self.get_language_set_by_id(language_set_id)
         if not language_set:
             return []
 
-        phrase_table = self._get_phrase_table(language_set["name"])
+        # Phrase ids are globally unique in the single phrases table.
+        phrase_table = phrases_table
 
         # Get phrase IDs from junction table
         junction_query = (


### PR DESCRIPTION
Replace the dynamic runtime-created phrases_<name> tables with a single phrases table keyed by language_set_id (FK, ON DELETE CASCADE). Rewrite PhrasesMixin and the private-list/teacher-access join paths to filter by language_set_id; remove the dynamic-table machinery (_get_phrase_table*, _ensure_phrase_table_exists, create_phrase_table, cache) and the per-set table create/drop in language_sets.

Alembic migration b2f1c0d4e5a6 creates the table, copies rows from every legacy phrases_<name> table, and remaps phrase_id references in user_private_list_phrases and teacher_phrase_set_phrases to the new global ids. Legacy tables are kept as a backup (drop in a follow-up migration once verified in prod).