### PR TITLE
refactor: migrate JSON-in-Text columns to native JSONB

### DIFF
--- a/backend/alembic/versions/d4e8b1a9c7f3_json_text_to_jsonb.py
+++ b/backend/alembic/versions/d4e8b1a9c7f3_json_text_to_jsonb.py
@@ -1,0 +1,54 @@
+"""Convert JSON-in-Text columns to native JSONB.
+
+Migrates the columns that stored JSON as `Text` to `JSONB` so they are queryable,
+indexable and validated at the database level:
+  - scoring_rules.difficulty_multipliers
+  - scoring_rules.target_times_seconds
+  - teacher_phrase_sets.config  (also gains a JSONB server_default)
+  - notifications.metadata
+
+The existing text values are already valid JSON, so `USING <col>::jsonb` casts
+them in place. NULLs (notifications.metadata) are preserved.
+
+Revision ID: d4e8b1a9c7f3
+Revises: c3a7e9d1f2b8
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d4e8b1a9c7f3"
+down_revision: Union[str, Sequence[str], None] = "c3a7e9d1f2b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# NOTE: spaces after each colon are required — SQLAlchemy's text() parser treats
+# ":true"/":false"/":null" as bind parameters, but ": true" is left as a literal.
+CONFIG_DEFAULT = (
+    '{"allow_hints": true, "show_translations": true, "require_translation_input": false, '
+    '"show_timer": false, "strict_grid_size": false, "grid_size": 10, '
+    '"time_limit_minutes": null, "difficulty": "medium"}'
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE scoring_rules ALTER COLUMN difficulty_multipliers TYPE jsonb USING difficulty_multipliers::jsonb"
+    )
+    op.execute(
+        "ALTER TABLE scoring_rules ALTER COLUMN target_times_seconds TYPE jsonb USING target_times_seconds::jsonb"
+    )
+    op.execute("ALTER TABLE teacher_phrase_sets ALTER COLUMN config TYPE jsonb USING config::jsonb")
+    op.execute(f"ALTER TABLE teacher_phrase_sets ALTER COLUMN config SET DEFAULT '{CONFIG_DEFAULT}'::jsonb")
+    op.execute("ALTER TABLE notifications ALTER COLUMN metadata TYPE jsonb USING metadata::jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE notifications ALTER COLUMN metadata TYPE text USING metadata::text")
+    op.execute("ALTER TABLE teacher_phrase_sets ALTER COLUMN config DROP DEFAULT")
+    op.execute("ALTER TABLE teacher_phrase_sets ALTER COLUMN config TYPE text USING config::text")
+    op.execute("ALTER TABLE scoring_rules ALTER COLUMN target_times_seconds TYPE text USING target_times_seconds::text")
+    op.execute(
+        "ALTER TABLE scoring_rules ALTER COLUMN difficulty_multipliers TYPE text USING difficulty_multipliers::text"
+    )

--- a/backend/osmosmjerka/database/models.py
+++ b/backend/osmosmjerka/database/models.py
@@ -14,7 +14,9 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 
 # Shared metadata for all tables
 metadata = MetaData()
@@ -152,9 +154,9 @@ scoring_rules_table = Table(
     metadata,
     Column("id", Integer, primary_key=True, index=True),
     Column("base_points_per_phrase", Integer, nullable=False, default=100),
-    Column("difficulty_multipliers", Text, nullable=False),  # JSON string of difficulty multipliers
+    Column("difficulty_multipliers", JSONB, nullable=False),  # {difficulty: multiplier}
     Column("max_time_bonus_ratio", String, nullable=False, default="0.3"),  # Stored as string to preserve precision
-    Column("target_times_seconds", Text, nullable=False),  # JSON string of target times
+    Column("target_times_seconds", JSONB, nullable=False),  # {difficulty: seconds}
     Column("completion_bonus_points", Integer, nullable=False, default=200),
     Column("hint_penalty_per_hint", Integer, nullable=False, default=75),
     Column("updated_at", DateTime, nullable=False, server_default=func.now()),
@@ -331,12 +333,18 @@ teacher_phrase_sets_table = Table(
         nullable=False,
         index=True,
     ),
-    # Game configuration stored as JSON string
+    # Game configuration stored as JSONB
     Column(
         "config",
-        Text,
+        JSONB,
         nullable=False,
-        default='{"allow_hints":true,"show_translations":true,"require_translation_input":false,"show_timer":false,"strict_grid_size":false,"grid_size":10,"time_limit_minutes":null,"difficulty":"medium"}',
+        # Spaces after colons are required: SQLAlchemy's text() parser would treat
+        # ":true"/":false"/":null" as bind parameters, but ": true" stays literal.
+        server_default=text(
+            '\'{"allow_hints": true, "show_translations": true, "require_translation_input": false, '
+            '"show_timer": false, "strict_grid_size": false, "grid_size": 10, '
+            '"time_limit_minutes": null, "difficulty": "medium"}\'::jsonb'
+        ),
     ),
     # Link management
     Column("current_hotlink_token", String(16), nullable=False, unique=True, index=True),
@@ -464,7 +472,7 @@ notifications_table = Table(
     Column("is_read", Boolean, nullable=False, default=False),
     Column("created_at", DateTime, nullable=False, server_default=func.now()),
     Column("expires_at", DateTime, nullable=True),  # For auto-cleanup
-    Column("metadata", Text, nullable=True),  # JSON string for extra data
+    Column("metadata", JSONB, nullable=True),  # extra structured data
     # Indexes
     Index("idx_notifications_user_read", "user_id", "is_read"),
     Index("idx_notifications_created_at", "created_at"),

--- a/backend/osmosmjerka/database/notifications.py
+++ b/backend/osmosmjerka/database/notifications.py
@@ -25,9 +25,11 @@ class NotificationsMixin:
         if notification.get("expires_at") and isinstance(notification["expires_at"], datetime):
             notification["expires_at"] = notification["expires_at"].isoformat()
 
-        if notification.get("metadata"):
+        # metadata is JSONB (returned as dict); tolerate legacy string rows.
+        meta = notification.get("metadata")
+        if isinstance(meta, str):
             try:
-                notification["metadata"] = json.loads(notification["metadata"])
+                notification["metadata"] = json.loads(meta)
             except json.JSONDecodeError:
                 notification["metadata"] = {}
         return notification
@@ -53,7 +55,7 @@ class NotificationsMixin:
             "link": link,
             "is_read": False,
             "expires_at": expires_at,
-            "metadata": json.dumps(metadata) if metadata else None,
+            "metadata": metadata if metadata else None,
         }
 
         query = insert(notifications_table).values(**values)

--- a/backend/osmosmjerka/database/scoring.py
+++ b/backend/osmosmjerka/database/scoring.py
@@ -1,7 +1,6 @@
 """Scoring rules and game scores database operations."""
 
 import datetime
-import json
 from typing import Any, Dict, List, Optional
 
 from osmosmjerka.database.models import accounts_table, game_scores_table, scoring_rules_table
@@ -24,9 +23,9 @@ class ScoringMixin:
 
         return {
             "base_points_per_phrase": result["base_points_per_phrase"],
-            "difficulty_multipliers": json.loads(result["difficulty_multipliers"]),
+            "difficulty_multipliers": result["difficulty_multipliers"],
             "max_time_bonus_ratio": float(result["max_time_bonus_ratio"]),
-            "target_times_seconds": json.loads(result["target_times_seconds"]),
+            "target_times_seconds": result["target_times_seconds"],
             "completion_bonus_points": result["completion_bonus_points"],
             "hint_penalty_per_hint": result["hint_penalty_per_hint"],
         }
@@ -47,9 +46,9 @@ class ScoringMixin:
 
         query = insert(scoring_rules_table).values(
             base_points_per_phrase=base_points_per_phrase,
-            difficulty_multipliers=json.dumps(difficulty_multipliers),
+            difficulty_multipliers=difficulty_multipliers,
             max_time_bonus_ratio=str(max_time_bonus_ratio),
-            target_times_seconds=json.dumps(target_times_seconds),
+            target_times_seconds=target_times_seconds,
             completion_bonus_points=completion_bonus_points,
             hint_penalty_per_hint=hint_penalty_per_hint,
             updated_by=updated_by,

--- a/backend/osmosmjerka/database/teacher_access.py
+++ b/backend/osmosmjerka/database/teacher_access.py
@@ -35,7 +35,7 @@ class TeacherSetsAccessMixin:
             return None
 
         row_dict = dict(result)
-        if row_dict.get("config"):
+        if isinstance(row_dict.get("config"), str):
             try:
                 row_dict["config"] = json.loads(row_dict["config"])
             except json.JSONDecodeError:
@@ -276,7 +276,7 @@ class TeacherSetsAccessMixin:
         puzzles = []
         for row in result:
             row_dict = dict(row)
-            if row_dict.get("config"):
+            if isinstance(row_dict.get("config"), str):
                 try:
                     row_dict["config"] = json.loads(row_dict["config"])
                 except json.JSONDecodeError:

--- a/backend/osmosmjerka/database/teacher_sets.py
+++ b/backend/osmosmjerka/database/teacher_sets.py
@@ -107,7 +107,7 @@ class TeacherSetsMixin:
             description=description,
             language_set_id=language_set_id,
             created_by=created_by,
-            config=json.dumps(final_config),
+            config=final_config,
             current_hotlink_token=hotlink_token,
             hotlink_version=1,
             access_type=access_type,
@@ -232,8 +232,8 @@ class TeacherSetsMixin:
         sets = []
         for row in result:
             row_dict = dict(row)
-            # Parse config JSON
-            if row_dict.get("config"):
+            # config is JSONB (returned as dict); tolerate legacy string rows.
+            if isinstance(row_dict.get("config"), str):
                 try:
                     row_dict["config"] = json.loads(row_dict["config"])
                 except json.JSONDecodeError:
@@ -325,7 +325,7 @@ class TeacherSetsMixin:
             return None
 
         row_dict = dict(result)
-        if row_dict.get("config"):
+        if isinstance(row_dict.get("config"), str):
             try:
                 row_dict["config"] = json.loads(row_dict["config"])
             except json.JSONDecodeError:
@@ -410,10 +410,7 @@ class TeacherSetsMixin:
                 # Check if sessions exist
                 if existing.get("session_count", 0) > 0:
                     raise ValueError(f"Cannot update {key}: set has existing sessions")  # noqa: S608
-                if key == "config":
-                    update_values[key] = json.dumps(value)
-                else:
-                    update_values[key] = value
+                update_values[key] = value
 
         if update_values:
             update_values["updated_at"] = datetime.utcnow()


### PR DESCRIPTION
## What

Converts the four columns that stored JSON as `Text` to native **JSONB**:
- `scoring_rules.difficulty_multipliers`, `scoring_rules.target_times_seconds`
- `teacher_phrase_sets.config`
- `notifications.metadata`

## Why

- **Queryable / indexable** — server-side filtering (`config->>'difficulty'`), GIN-index ready. Text was opaque.
- **Validated at the DB** — Postgres rejects malformed JSON on write; removes the need for `try/except JSONDecodeError` fallbacks.
- **Cleaner code** — the driver round-trips Python dicts directly.

## Key implementation detail

With SQLAlchemy Core `JSONB` over the `databases`/asyncpg stack, **both** bind and result processors round-trip Python dicts automatically. So every manual `json.dumps` (write) and `json.loads` (read) had to be removed — leaving `json.dumps` in place would double-encode the value into a JSON *string scalar* (verified: dict-write → `jsonb_typeof = object`; str-write → scalar string, not queryable). Reads remain tolerant of legacy string rows via `isinstance(x, str)`.

`teacher_phrase_sets.config` also gains a JSONB `server_default` (the client-side default was unreliable through raw inserts).

> Note: SQLAlchemy's `text()` parses `:true`/`:false`/`:null` as bind params, so the default JSON literal uses spaces after colons.

## Migration

`d4e8b1a9c7f3` casts existing text values in place (`USING col::jsonb`) and is fully reversible (`downgrade` casts back to `text`).

## Testing

Verified against a throwaway Postgres 18:
- **Migration**: upgrade converts all four columns to `jsonb`, data intact, JSONB operators work, `config` server_default applies on bare insert; `downgrade` reverts cleanly to `text`.
- **Runtime (real app code)**: scoring / notifications / teacher-config all round-trip dicts; `None` metadata preserved; `jsonb_typeof = object` for all three (no double-encoding).
- `ruff check` + `ruff format` clean; **319 backend tests pass**.

## Storage impact

JSONB is ~6–30% *larger* than compact JSON text for these small objects (binary header + per-key offsets), but the row counts are tiny (config/scoring/notifications), so absolute impact is negligible. The win is query/index/validate, not size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)