### PR TITLE
refactor: scoring cleanup — single source of truth + stop penalizing hints

### DIFF
--- a/backend/alembic/versions/e5f9c2a1b6d4_zero_hint_penalty.py
+++ b/backend/alembic/versions/e5f9c2a1b6d4_zero_hint_penalty.py
@@ -1,0 +1,29 @@
+"""Stop penalizing hints by default: zero out existing hint_penalty_per_hint.
+
+Hints (revealing a word/direction) are a learning moment, so the default penalty is
+now 0. New installs get 0 from the code defaults; this migration updates existing
+deployments' stored scoring_rules rows so they stop penalizing immediately. Admins
+can re-raise the value via the scoring rules editor.
+
+Revision ID: e5f9c2a1b6d4
+Revises: d4e8b1a9c7f3
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e5f9c2a1b6d4"
+down_revision: Union[str, Sequence[str], None] = "d4e8b1a9c7f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE scoring_rules SET hint_penalty_per_hint = 0")
+
+
+def downgrade() -> None:
+    # Best-effort restore of the previous default (75). Not a true inverse: any
+    # admin-customized value cannot be recovered from here.
+    op.execute("UPDATE scoring_rules SET hint_penalty_per_hint = 75")

--- a/backend/osmosmjerka/database/models.py
+++ b/backend/osmosmjerka/database/models.py
@@ -158,7 +158,7 @@ scoring_rules_table = Table(
     Column("max_time_bonus_ratio", String, nullable=False, default="0.3"),  # Stored as string to preserve precision
     Column("target_times_seconds", JSONB, nullable=False),  # {difficulty: seconds}
     Column("completion_bonus_points", Integer, nullable=False, default=200),
-    Column("hint_penalty_per_hint", Integer, nullable=False, default=75),
+    Column("hint_penalty_per_hint", Integer, nullable=False, default=0),  # hints not penalized by default
     Column("updated_at", DateTime, nullable=False, server_default=func.now()),
     Column("updated_by", Integer, nullable=False, default=0),  # User ID of who made the change
     Column("game_type", String(20), nullable=False, default="word_search"),  # word_search, crossword

--- a/backend/osmosmjerka/scoring_rules.py
+++ b/backend/osmosmjerka/scoring_rules.py
@@ -42,8 +42,10 @@ TARGET_TIMES_SECONDS: Dict[str, int] = {
 # Bonus for completing the entire puzzle (finding every phrase).
 COMPLETION_BONUS_POINTS: int = 200
 
-# Points deducted for each hint the player uses.
-HINT_PENALTY_PER_HINT: int = 75
+# Points deducted for each hint the player uses. Defaults to 0: revealing a
+# word/direction is a learning moment, so hints are not penalized by default.
+# Admins can still raise this via the scoring rules editor.
+HINT_PENALTY_PER_HINT: int = 0
 
 # Public representation ------------------------------------------------------
 

--- a/backend/tests/test_game_api.py
+++ b/backend/tests/test_game_api.py
@@ -75,7 +75,7 @@ def test_get_scoring_rules(client):
     assert rules["base_points_per_phrase"] == 100
     assert set(rules["difficulty_multipliers"].keys()) == {"very_easy", "easy", "medium", "hard", "very_hard"}
     assert rules["completion_bonus_points"] == 200
-    assert rules["hint_penalty_per_hint"] == 75
+    assert rules["hint_penalty_per_hint"] == 0  # hints not penalized by default
     assert "time_bonus" in rules and "target_times_seconds" in rules["time_bonus"]
 
 
@@ -115,9 +115,9 @@ def test_calculate_score_endpoint(client):
         assert data["difficulty_bonus"] == 0
         assert data["time_bonus"] == 0  # not all phrases found
         assert data["streak_bonus"] == 0
-        assert data["hint_penalty"] == 75
-    assert data["final_score"] == 425
-    assert data["hint_penalty_per_hint"] == 75
+        assert data["hint_penalty"] == 0  # hints not penalized by default
+    assert data["final_score"] == 500
+    assert data["hint_penalty_per_hint"] == 0
 
 
 def test_get_grid_size_and_num_phrases_very_easy():

--- a/frontend/src/hooks/useScoring.js
+++ b/frontend/src/hooks/useScoring.js
@@ -2,7 +2,7 @@ import logger from '@shared/utils/logger';
 import axios from "axios";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { API_ENDPOINTS, STORAGE_KEYS } from "../shared/constants/constants";
-import { calculateScoreClientSide, DEFAULT_SCORING_RULES } from "../utils/scoringUtils";
+import { estimateScoreOffline, FALLBACK_SCORING_RULES } from "../utils/scoringUtils";
 
 export function useScoring({
   scoringEnabled,
@@ -95,7 +95,7 @@ export function useScoring({
           per_phrase: perPhraseBreakdown,
           hints_used: hintsUsed,
           hint_penalty_per_hint:
-            scoringRules?.hint_penalty_per_hint ?? DEFAULT_SCORING_RULES.hint_penalty_per_hint,
+            scoringRules?.hint_penalty_per_hint ?? FALLBACK_SCORING_RULES.hint_penalty_per_hint,
           duration_seconds: durationSeconds,
           difficulty,
           total_phrases: phrases.length,
@@ -124,17 +124,9 @@ export function useScoring({
 
   const calculateScoreFromApi = useCallback(
     async ({ phrasesFound, totalPhrases, durationSeconds, hintsCount }) => {
-      const token = localStorage.getItem(STORAGE_KEYS.ADMIN_TOKEN);
-      if (!token) {
-        return calculateScoreClientSide(
-          difficulty,
-          phrasesFound,
-          totalPhrases,
-          durationSeconds,
-          hintsCount,
-          scoringRules || DEFAULT_SCORING_RULES
-        );
-      }
+      // Single source of truth: the public /system/calculate-score endpoint, used
+      // for both anonymous and authenticated users. Only fall back to a local
+      // estimate if the API is unreachable.
       try {
         const response = await axios.post(`${API_ENDPOINTS.GAME}/system/calculate-score`, {
           difficulty,
@@ -145,14 +137,13 @@ export function useScoring({
         });
         return response.data;
       } catch (error) {
-        logger.error("Failed to calculate score from API, falling back to client-side:", error);
-        return calculateScoreClientSide(
+        logger.error("Failed to calculate score from API, using offline estimate:", error);
+        return estimateScoreOffline(
           difficulty,
           phrasesFound,
           totalPhrases,
-          durationSeconds,
           hintsCount,
-          scoringRules || DEFAULT_SCORING_RULES
+          scoringRules || FALLBACK_SCORING_RULES
         );
       }
     },
@@ -189,8 +180,8 @@ export function useScoring({
     });
     if (!result) return;
 
-    const basePoints = scoringRules?.base_points_per_phrase ?? DEFAULT_SCORING_RULES.base_points_per_phrase;
-    const multiplierMap = scoringRules?.difficulty_multipliers ?? DEFAULT_SCORING_RULES.difficulty_multipliers;
+    const basePoints = scoringRules?.base_points_per_phrase ?? FALLBACK_SCORING_RULES.base_points_per_phrase;
+    const multiplierMap = scoringRules?.difficulty_multipliers ?? FALLBACK_SCORING_RULES.difficulty_multipliers;
     const multiplier = multiplierMap?.[difficulty] ?? 1;
     const perPhraseEntries = found.map((phraseValue, index) => {
       const phraseObj = phrases.find((item) =>
@@ -208,7 +199,7 @@ export function useScoring({
       hint_penalty_per_hint:
         result.hint_penalty_per_hint ??
         scoringRules?.hint_penalty_per_hint ??
-        DEFAULT_SCORING_RULES.hint_penalty_per_hint,
+        FALLBACK_SCORING_RULES.hint_penalty_per_hint,
       duration_seconds: currentElapsedTimeRef.current,
       difficulty,
       total_phrases: totalPhrases,

--- a/frontend/src/utils/__tests__/scoringUtils.test.js
+++ b/frontend/src/utils/__tests__/scoringUtils.test.js
@@ -1,130 +1,85 @@
-import { calculateScoreClientSide, DEFAULT_SCORING_RULES } from '../scoringUtils';
+import { estimateScoreOffline, FALLBACK_SCORING_RULES } from '../scoringUtils';
 
-describe('scoringUtils', () => {
-    describe('calculateScoreClientSide', () => {
+describe('scoringUtils (offline fallback)', () => {
+    describe('estimateScoreOffline', () => {
         it('should calculate base score correctly', () => {
-            const result = calculateScoreClientSide('easy', 5, 10, 300, 0);
+            const result = estimateScoreOffline('easy', 5, 10, 0);
 
             expect(result.base_score).toBe(500); // 5 phrases * 100 points
             expect(result.final_score).toBeGreaterThan(0);
         });
 
         it('should apply difficulty multiplier for very_hard', () => {
-            const result = calculateScoreClientSide('very_hard', 5, 10, 300, 0);
+            const result = estimateScoreOffline('very_hard', 5, 10, 0);
 
-            // very_hard multiplier is 2.0
-            // difficulty bonus = baseScore * (2.0 - 1.0) = 500 * 1.0 = 500
+            // very_hard multiplier is 2.0 -> bonus = 500 * (2.0 - 1.0) = 500
             expect(result.difficulty_bonus).toBe(500);
             expect(result.base_score).toBe(500);
         });
 
-        it('should apply difficulty multiplier for very_easy', () => {
-            const result = calculateScoreClientSide('very_easy', 5, 10, 300, 0);
+        it('should apply difficulty multiplier for very_easy (matches backend 0.8)', () => {
+            const result = estimateScoreOffline('very_easy', 5, 10, 0);
 
-            // very_easy multiplier is 0.9
-            // difficulty bonus = baseScore * (0.9 - 1.0) = 500 * -0.1 = -50
-            expect(result.difficulty_bonus).toBe(-50);
+            // very_easy multiplier is 0.8 -> bonus = 500 * (0.8 - 1.0) = -100
+            expect(result.difficulty_bonus).toBe(-100);
         });
 
         it('should award completion bonus when all phrases found', () => {
-            const result = calculateScoreClientSide('easy', 10, 10, 300, 0);
+            const result = estimateScoreOffline('easy', 10, 10, 0);
 
             expect(result.streak_bonus).toBe(200);
             expect(result.base_score).toBe(1000);
         });
 
         it('should not award completion bonus when not all phrases found', () => {
-            const result = calculateScoreClientSide('easy', 5, 10, 300, 0);
+            const result = estimateScoreOffline('easy', 5, 10, 0);
 
             expect(result.streak_bonus).toBe(0);
         });
 
-        it('should calculate time bonus for fast completion', () => {
-            // For easy difficulty, target time is 300 seconds
-            // Completing in 150 seconds should give a time bonus
-            const result = calculateScoreClientSide('easy', 10, 10, 150, 0);
-
-            expect(result.time_bonus).toBeGreaterThan(0);
-            // Time ratio = (300 - 150) / 300 = 0.5
-            // Time bonus = 1000 * 0.3 * 0.5 = 150
-            expect(result.time_bonus).toBe(150);
-        });
-
-        it('should not give time bonus if completed slower than target', () => {
-            const result = calculateScoreClientSide('easy', 10, 10, 400, 0);
+        it('should not include a time bonus (degraded offline estimate)', () => {
+            const result = estimateScoreOffline('easy', 10, 10, 0);
 
             expect(result.time_bonus).toBe(0);
         });
 
-        it('should not give time bonus if not all phrases found', () => {
-            const result = calculateScoreClientSide('easy', 5, 10, 150, 0);
+        it('should not penalize hints by default', () => {
+            const result = estimateScoreOffline('easy', 5, 10, 3);
 
-            expect(result.time_bonus).toBe(0);
-        });
-
-        it('should apply hint penalty', () => {
-            const result = calculateScoreClientSide('easy', 5, 10, 300, 3);
-
-            expect(result.hint_penalty).toBe(225); // 3 hints * 75 points
+            expect(result.hint_penalty).toBe(0); // default hint penalty is 0
             expect(result.hints_used).toBe(3);
         });
 
-        it('should calculate final score correctly with all components', () => {
-            // Fast completion with all phrases and no hints
-            const result = calculateScoreClientSide('medium', 10, 10, 300, 0);
+        it('should apply a hint penalty when custom rules set one', () => {
+            const customRules = { ...FALLBACK_SCORING_RULES, hint_penalty_per_hint: 100 };
+            const result = estimateScoreOffline('easy', 5, 10, 2, customRules);
 
-            // Base: 1000
-            // Difficulty bonus (medium = 1.2): 1000 * 0.2 = 200
-            // Time bonus (600 target, 300 actual): 1000 * 0.3 * 0.5 = 150 (floored to 149)
-            // Completion bonus: 200
-            // Hint penalty: 0
-            // Total: 1000 + 200 + 149 + 200 = 1549
-            expect(result.final_score).toBe(1549);
+            expect(result.hint_penalty).toBe(200); // 2 * 100
         });
 
         it('should not allow negative scores', () => {
-            // Use many hints to potentially go negative
-            const result = calculateScoreClientSide('very_easy', 1, 10, 300, 10);
+            const customRules = { ...FALLBACK_SCORING_RULES, hint_penalty_per_hint: 1000 };
+            const result = estimateScoreOffline('very_easy', 1, 10, 10, customRules);
 
             expect(result.final_score).toBeGreaterThanOrEqual(0);
         });
 
-        it('should use default rules when no rules provided', () => {
-            const result = calculateScoreClientSide('easy', 5, 10, 300, 0);
-
-            expect(result.base_score).toBe(500);
-            expect(result.hint_penalty_per_hint).toBe(DEFAULT_SCORING_RULES.hint_penalty_per_hint);
-        });
-
-        it('should use custom rules when provided', () => {
-            const customRules = {
-                ...DEFAULT_SCORING_RULES,
-                base_points_per_phrase: 200,
-                hint_penalty_per_hint: 100,
-            };
-
-            const result = calculateScoreClientSide('easy', 5, 10, 300, 2, customRules);
+        it('should use custom base points when provided', () => {
+            const customRules = { ...FALLBACK_SCORING_RULES, base_points_per_phrase: 200 };
+            const result = estimateScoreOffline('easy', 5, 10, 0, customRules);
 
             expect(result.base_score).toBe(1000); // 5 * 200
-            expect(result.hint_penalty).toBe(200); // 2 * 100
         });
 
         it('should default to easy difficulty multiplier for unknown difficulty', () => {
-            const result = calculateScoreClientSide('unknown_difficulty', 5, 10, 300, 0);
+            const result = estimateScoreOffline('unknown_difficulty', 5, 10, 0);
 
-            // Should use easy multiplier (1.0), so difficulty bonus = 0
+            // Falls back to easy multiplier (1.0), so difficulty bonus = 0
             expect(result.difficulty_bonus).toBe(0);
         });
 
-        it('should handle edge case of 0 duration', () => {
-            const result = calculateScoreClientSide('easy', 10, 10, 0, 0);
-
-            // Time bonus should be 0 when duration is 0
-            expect(result.time_bonus).toBe(0);
-        });
-
         it('should return all score breakdown components', () => {
-            const result = calculateScoreClientSide('hard', 7, 10, 450, 2);
+            const result = estimateScoreOffline('hard', 7, 10, 2);
 
             expect(result).toHaveProperty('base_score');
             expect(result).toHaveProperty('difficulty_bonus');
@@ -137,17 +92,25 @@ describe('scoringUtils', () => {
         });
     });
 
-    describe('DEFAULT_SCORING_RULES', () => {
+    describe('FALLBACK_SCORING_RULES', () => {
         it('should have all required properties', () => {
-            expect(DEFAULT_SCORING_RULES).toHaveProperty('base_points_per_phrase');
-            expect(DEFAULT_SCORING_RULES).toHaveProperty('completion_bonus_points');
-            expect(DEFAULT_SCORING_RULES).toHaveProperty('difficulty_multipliers');
-            expect(DEFAULT_SCORING_RULES).toHaveProperty('hint_penalty_per_hint');
-            expect(DEFAULT_SCORING_RULES).toHaveProperty('time_bonus');
+            expect(FALLBACK_SCORING_RULES).toHaveProperty('base_points_per_phrase');
+            expect(FALLBACK_SCORING_RULES).toHaveProperty('completion_bonus_points');
+            expect(FALLBACK_SCORING_RULES).toHaveProperty('difficulty_multipliers');
+            expect(FALLBACK_SCORING_RULES).toHaveProperty('hint_penalty_per_hint');
+            expect(FALLBACK_SCORING_RULES).toHaveProperty('time_bonus');
+        });
+
+        it('should not penalize hints by default', () => {
+            expect(FALLBACK_SCORING_RULES.hint_penalty_per_hint).toBe(0);
+        });
+
+        it('should mirror the backend very_easy multiplier (0.8)', () => {
+            expect(FALLBACK_SCORING_RULES.difficulty_multipliers.very_easy).toBe(0.8);
         });
 
         it('should have all difficulty multipliers', () => {
-            const multipliers = DEFAULT_SCORING_RULES.difficulty_multipliers;
+            const multipliers = FALLBACK_SCORING_RULES.difficulty_multipliers;
 
             expect(multipliers).toHaveProperty('very_easy');
             expect(multipliers).toHaveProperty('easy');
@@ -157,7 +120,7 @@ describe('scoringUtils', () => {
         });
 
         it('should have target times for all difficulties', () => {
-            const targetTimes = DEFAULT_SCORING_RULES.time_bonus.target_times_seconds;
+            const targetTimes = FALLBACK_SCORING_RULES.time_bonus.target_times_seconds;
 
             expect(targetTimes).toHaveProperty('very_easy');
             expect(targetTimes).toHaveProperty('easy');

--- a/frontend/src/utils/scoringUtils.js
+++ b/frontend/src/utils/scoringUtils.js
@@ -1,19 +1,26 @@
 /**
- * Scoring utilities for game score calculation
- * Mirrors the backend calculation logic exactly
+ * Offline fallback scoring helpers.
+ *
+ * The backend is the single source of truth for scores: previews come from
+ * `/system/calculate-score` (a public endpoint) and the authoritative saved score
+ * comes from `/game/score`. These helpers exist ONLY as a last-resort fallback for
+ * when the scoring API is unreachable, so they are intentionally minimal and must
+ * not re-implement the full backend formula.
  */
 
-export const DEFAULT_SCORING_RULES = {
+// Minimal rules used only for offline display fallbacks. Values mirror the backend
+// defaults; the backend remains the source of truth if the two ever diverge.
+export const FALLBACK_SCORING_RULES = {
     base_points_per_phrase: 100,
     completion_bonus_points: 200,
     difficulty_multipliers: {
-        very_easy: 0.9,
+        very_easy: 0.8,
         easy: 1.0,
         medium: 1.2,
         hard: 1.5,
         very_hard: 2.0,
     },
-    hint_penalty_per_hint: 75,
+    hint_penalty_per_hint: 0,
     time_bonus: {
         max_ratio: 0.3,
         target_times_seconds: {
@@ -27,74 +34,35 @@ export const DEFAULT_SCORING_RULES = {
 };
 
 /**
- * Client-side score calculation for anonymous users
- * Mirrors the backend calculation logic exactly
- * 
+ * Last-resort offline score estimate, used only when the scoring API is
+ * unreachable. Deliberately simplified (base points × difficulty + completion
+ * bonus, no time bonus) — the backend is the single source of truth for real
+ * scores, and this is a degraded preview only.
+ *
  * @param {string} difficulty - Game difficulty level
  * @param {number} phrasesFound - Number of phrases found
  * @param {number} totalPhrases - Total number of phrases in the game
- * @param {number} durationSeconds - Time taken in seconds
  * @param {number} hintsUsed - Number of hints used
- * @param {Object} rules - Scoring rules object (optional, defaults to DEFAULT_SCORING_RULES)
- * @returns {Object} Score breakdown with base_score, difficulty_bonus, time_bonus, etc.
+ * @param {Object} [rules] - Scoring rules (defaults to FALLBACK_SCORING_RULES)
+ * @returns {Object} Score breakdown matching the backend response shape
  */
-export function calculateScoreClientSide(
-    difficulty,
-    phrasesFound,
-    totalPhrases,
-    durationSeconds,
-    hintsUsed,
-    rules = DEFAULT_SCORING_RULES
-) {
-    const scoringRules = rules || DEFAULT_SCORING_RULES;
-
-    // Base score: constant points per phrase found
-    const baseScore = phrasesFound * scoringRules.base_points_per_phrase;
-
-    // Difficulty multipliers determine the size of the bonus
-    const difficultyMultiplier =
-        scoringRules.difficulty_multipliers[difficulty] ||
-        scoringRules.difficulty_multipliers.easy;
-    const difficultyBonus = Math.floor(baseScore * (difficultyMultiplier - 1.0));
-
-    // Time bonus (faster completion = higher bonus)
-    let timeBonus = 0;
-    if (phrasesFound === totalPhrases && durationSeconds > 0) {
-        const targetTime =
-            scoringRules.time_bonus.target_times_seconds[difficulty] ||
-            scoringRules.time_bonus.target_times_seconds.medium;
-        if (targetTime > 0 && durationSeconds <= targetTime) {
-            const timeRatio = Math.max(
-                0.0,
-                (targetTime - durationSeconds) / targetTime
-            );
-            timeBonus = Math.floor(
-                baseScore * scoringRules.time_bonus.max_ratio * timeRatio
-            );
-        }
-    }
-
-    // Completion bonus for finding all phrases
-    const streakBonus =
-        phrasesFound === totalPhrases ? scoringRules.completion_bonus_points : 0;
-
-    // Hint penalty: fixed deduction per hint used
-    const hintPenalty = hintsUsed * scoringRules.hint_penalty_per_hint;
-
-    // Calculate final score
-    const finalScore = Math.max(
-        0,
-        baseScore + difficultyBonus + timeBonus + streakBonus - hintPenalty
-    );
+export function estimateScoreOffline(difficulty, phrasesFound, totalPhrases, hintsUsed, rules = FALLBACK_SCORING_RULES) {
+    const r = rules || FALLBACK_SCORING_RULES;
+    const baseScore = phrasesFound * r.base_points_per_phrase;
+    const multiplier = r.difficulty_multipliers[difficulty] ?? r.difficulty_multipliers.easy;
+    const difficultyBonus = Math.floor(baseScore * (multiplier - 1.0));
+    const streakBonus = phrasesFound === totalPhrases ? r.completion_bonus_points : 0;
+    const hintPenalty = hintsUsed * r.hint_penalty_per_hint;
+    const finalScore = Math.max(0, baseScore + difficultyBonus + streakBonus - hintPenalty);
 
     return {
         base_score: baseScore,
         difficulty_bonus: difficultyBonus,
-        time_bonus: timeBonus,
+        time_bonus: 0,
         streak_bonus: streakBonus,
         hint_penalty: hintPenalty,
         final_score: finalScore,
         hints_used: hintsUsed,
-        hint_penalty_per_hint: scoringRules.hint_penalty_per_hint,
+        hint_penalty_per_hint: r.hint_penalty_per_hint,
     };
 }


### PR DESCRIPTION
Interim scoring cleanup ahead of the larger learning-modes revamp. Three slices were scoped; **A** and **C** are done here, **B** is deferred.

## A — Single source of truth (done)
The backend was already authoritative for saved scores (`/game/score`) and logged-in previews. This routes **all** previews — anonymous included — through the public `/system/calculate-score` endpoint and **deletes the client-side formula mirror** (`calculateScoreClientSide` / `DEFAULT_SCORING_RULES`), which had already drifted (`very_easy: 0.9` on the frontend vs `0.8` on the backend). It's replaced by a minimal, corrected offline fallback (`estimateScoreOffline` / `FALLBACK_SCORING_RULES`) used only when the API is unreachable (degraded preview; the backend remains the source of truth).

## C — Stop penalizing hints (done)
Revealing a word/direction is a learning moment, so `HINT_PENALTY_PER_HINT` now defaults to **0** (code constant + model default). Migration `e5f9c2a1b6d4` zeroes existing `scoring_rules` rows so current deployments stop penalizing immediately. Admins can still raise it via the scoring rules editor.

## B — Rename `streak_bonus` → `completion_bonus` (deferred)
The name is misleading (it's a per-puzzle completion bonus, not a streak), but renaming needs a DB column-rename migration + churn across FE/BE/tests, and the upcoming learning-modes revamp will rework scoring anyway. Deferred into that work. `ScoreDisplay.jsx` already reads `streak_bonus ?? completion_bonus`, so it's forward-compatible.

## Testing
- Frontend: eslint clean, **423 tests pass** (scoringUtils test rewritten for the new fallback API).
- Backend: ruff check + format clean, **319 tests pass** (updated hint-penalty assertions).
- Migration `e5f9c2a1b6d4` verified on a throwaway Postgres 18: upgrade sets rows to 0, downgrade restores 75.