### PR TITLE
fix: show app version in footer on mobile

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -851,29 +851,26 @@ function AppContent() {
             px: 2,
           }}
         >
-          {!useMobileLayout && (
-            <>
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                component="a"
-                href={`https://github.com/bartekmp/osmosmjerka/releases/tag/v${appVersion}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={{
-                  textDecoration: "none",
-                  color: "text.secondary",
-                  "&:hover": {
-                    textDecoration: "underline",
-                    color: "primary.main",
-                  },
-                }}
-              >
-                Osmosmjerka v{appVersion}
-              </Typography>
-              <Box sx={{ height: 20, width: 1, bgcolor: "divider" }} />
-            </>
-          )}
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            component="a"
+            href={`https://github.com/bartekmp/osmosmjerka/releases/tag/v${appVersion}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              textDecoration: "none",
+              color: "text.secondary",
+              fontSize: useMobileLayout ? "0.75rem" : undefined,
+              "&:hover": {
+                textDecoration: "underline",
+                color: "primary.main",
+              },
+            }}
+          >
+            Osmosmjerka v{appVersion}
+          </Typography>
+          <Box sx={{ height: 20, width: 1, bgcolor: "divider" }} />
           <IconButton
             size="small"
             href="https://github.com/bartekmp/osmosmjerka"


### PR DESCRIPTION
## What
The footer app-version link (`Osmosmjerka v{appVersion}`) was wrapped in `{!useMobileLayout && (...)}`, so on mobile only the GitHub icon rendered and the version string disappeared.

## Change
Render the version link on all layouts, with a slightly smaller font (`0.75rem`) on mobile so it sits comfortably next to the GitHub icon. Single file (`frontend/src/App.jsx`).

## Testing
eslint clean, 423 frontend tests pass.