### PR TITLE
ci: disposable per-branch preview environments (Docker + prod DB clone)

### DIFF
--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -1,0 +1,91 @@
+// Jenkins pipeline for on-demand, disposable per-branch preview environments.
+//
+// A SEPARATE, manually-triggered pipeline (not part of the CD Jenkinsfile). Configure as a
+// "Pipeline script from SCM" job pointing at this file. It builds the chosen branch's app
+// image, spins it up against a throwaway clone of the PROD DB, and publishes it on a random
+// high port on the Jenkins host. See helpers/preview/README.md.
+//
+// Reuses the same credentials/env as the main Jenkinsfile:
+//   credentials: osmosmjerka-db-user, osmosmjerka-db-password,
+//                osmosmjerka-admin-username, osmosmjerka-admin-password-hash,
+//                osmosmjerka-admin-secret-key
+//   env (global): OSMOSMJERKA_POSTGRES_HOST / _PORT / _DATABASE  (prod DB, the clone source)
+
+pipeline {
+  agent any
+
+  parameters {
+    choice(name: 'ACTION',  choices: ['up', 'down', 'list', 'cleanup'], description: 'What to do')
+    string(name: 'BRANCH',     defaultValue: '',   description: 'Branch to preview (ACTION=up; must not be main)')
+    string(name: 'PREVIEW_ID', defaultValue: '',   description: 'Preview id to destroy (ACTION=down)')
+    string(name: 'MAX_HOURS',  defaultValue: '24', description: 'Age threshold in hours (ACTION=cleanup)')
+    string(name: 'REPO_URL',   defaultValue: 'https://github.com/bartekmp/osmosmjerka.git', description: 'Git repo URL')
+  }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+  }
+
+  environment {
+    // Clone source = prod DB (same creds/env the CD pipeline uses).
+    SOURCE_DB_HOST     = "${env.OSMOSMJERKA_POSTGRES_HOST}"
+    SOURCE_DB_PORT     = "${env.OSMOSMJERKA_POSTGRES_PORT}"
+    SOURCE_DB_NAME     = "${env.OSMOSMJERKA_POSTGRES_DATABASE}"
+    SOURCE_DB_USER     = credentials('osmosmjerka-db-user')
+    SOURCE_DB_PASSWORD = credentials('osmosmjerka-db-password')
+
+    // App admin secrets for the preview (same ids as the CD pipeline).
+    ADMIN_USERNAME      = credentials('osmosmjerka-admin-username')
+    ADMIN_PASSWORD_HASH = credentials('osmosmjerka-admin-password-hash')
+    ADMIN_SECRET_KEY    = credentials('osmosmjerka-admin-secret-key')
+
+    // Host learners will reach the preview on; override in job config if needed.
+    PREVIEW_HOST        = "${env.PREVIEW_HOST ?: 'localhost'}"
+  }
+
+  stages {
+    stage('Validate') {
+      steps {
+        script {
+          if (params.ACTION == 'up' && (!params.BRANCH?.trim() || params.BRANCH == 'main')) {
+            error 'ACTION=up requires a BRANCH that is not "main"'
+          }
+          if (params.ACTION == 'down' && !params.PREVIEW_ID?.trim()) {
+            error 'ACTION=down requires PREVIEW_ID'
+          }
+        }
+      }
+    }
+
+    // Check out the target branch's code into ./app so `docker build` uses it, while the
+    // preview tooling itself stays on the (stable) branch this Jenkinsfile is loaded from.
+    stage('Checkout target branch') {
+      when { expression { params.ACTION == 'up' } }
+      steps {
+        dir('app') {
+          checkout([$class: 'GitSCM',
+            branches: [[name: "*/${params.BRANCH}"]],
+            userRemoteConfigs: [[url: params.REPO_URL]]])
+        }
+      }
+    }
+
+    stage('Run') {
+      steps {
+        sh 'chmod +x helpers/preview/preview-env.sh'
+        script {
+          if (params.ACTION == 'up') {
+            sh "REPO_ROOT='${WORKSPACE}/app' helpers/preview/preview-env.sh up '${params.BRANCH}'"
+          } else if (params.ACTION == 'down') {
+            sh "helpers/preview/preview-env.sh down '${params.PREVIEW_ID}'"
+          } else if (params.ACTION == 'list') {
+            sh 'helpers/preview/preview-env.sh list'
+          } else if (params.ACTION == 'cleanup') {
+            sh "helpers/preview/preview-env.sh cleanup '${params.MAX_HOURS}'"
+          }
+        }
+      }
+    }
+  }
+}

--- a/helpers/preview/README.md
+++ b/helpers/preview/README.md
@@ -1,0 +1,93 @@
+# Branch preview environments
+
+Spin up a **disposable, full-app preview** of any branch (not `main`) on the Jenkins host,
+backed by a **throwaway clone of the prod database**. Pure Docker — no Kubernetes, no Flux.
+Meant for a quick "build it, click around, throw it away" loop.
+
+This is a **separate, manually-triggered** pipeline — it is *not* part of the CD
+`Jenkinsfile` (which builds on GitHub-Actions success and deploys via gitops/Flux) or the
+prod `Jenkinsfile.promotion`.
+
+Each preview is:
+
+- a dedicated docker **network**,
+- a throwaway **Postgres sidecar** cloned from prod (previews never touch prod itself),
+- the **app image** built from the branch, published on a **random high port**.
+
+Everything is labelled `com.osmosmjerka.preview=<id>` so it can be torn down cleanly.
+
+## What happens on `up`
+
+1. `docker build` the app image from the branch checkout (the standard multi-stage `Dockerfile`).
+2. Start a throwaway `postgres:18` sidecar.
+3. **Clone prod → sidecar** (`pg_dump | psql`). The clone runs on the **host network** so it
+   reaches prod exactly like the Jenkins host does (incl. Tailscale/VPN), and restores into
+   the sidecar via its published port.
+4. **`alembic upgrade head`** against the clone — applies **only the branch's new migrations**
+   on top of prod's schema (this is the point: test branch migrations safely).
+5. Run the app container against the sidecar, published on a random high port.
+6. Print the URL + the preview id + the teardown command.
+
+## Usage (script)
+
+```bash
+# Source DB to clone FROM (prod): a URL, or the discrete params below.
+export SOURCE_DB_HOST='prod-host' SOURCE_DB_PORT='5432' SOURCE_DB_NAME='osmosmjerka'
+export SOURCE_DB_USER='...' SOURCE_DB_PASSWORD='...'
+# (alternatively: export SOURCE_DATABASE_URL='postgresql://user:pass@prod-host:5432/osmosmjerka')
+
+# App admin secrets for the preview (same names the app + main Jenkinsfile use).
+export ADMIN_USERNAME='root'
+export ADMIN_PASSWORD_HASH='<bcrypt hash>'
+export ADMIN_SECRET_KEY='<random secret>'
+
+helpers/preview/preview-env.sh up my-feature-branch    # build + run; prints URL + id
+helpers/preview/preview-env.sh list                    # list running previews
+helpers/preview/preview-env.sh down <preview-id>       # destroy one preview
+helpers/preview/preview-env.sh cleanup 24              # destroy previews older than 24h (TTL)
+```
+
+Generate an admin password hash:
+
+```bash
+python3 -c "import bcrypt,getpass; print(bcrypt.hashpw(getpass.getpass().encode(), bcrypt.gensalt()).decode())"
+```
+
+### Optional env
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `PREVIEW_PG_IMAGE` | `postgres:18` | Postgres image for the sidecar/clone |
+| `PREVIEW_HOST` | `localhost` | Hostname printed in the URL |
+| `REPO_ROOT` | git toplevel of CWD | Path to the checked-out repo to build |
+| `PREVIEW_SKIP_MIGRATIONS` | `0` | Set `1` to skip `alembic upgrade head` after cloning |
+
+## Usage (Jenkins)
+
+Create a **Pipeline script from SCM** job pointing at `Jenkinsfile.preview`, then run
+it with the `ACTION` parameter (`up` / `down` / `list` / `cleanup`).
+
+It **reuses the same credentials/env as the CD `Jenkinsfile`** — no new secrets to create:
+
+| Source | Used as |
+|--------|---------|
+| `OSMOSMJERKA_POSTGRES_HOST` / `_PORT` / `_DATABASE` (global env) | prod DB host/port/name (clone source) |
+| credential `osmosmjerka-db-user` / `osmosmjerka-db-password` | prod DB user/password |
+| credential `osmosmjerka-admin-username` / `-admin-password-hash` / `-admin-secret-key` | preview admin login |
+
+For `up`, the job checks out the chosen branch into `./app` and builds from there, so the
+preview tooling stays on the branch the Jenkinsfile is loaded from.
+
+## Notes & caveats
+
+- **Prod reachability**: the clone step uses the host network, so the Jenkins host must be
+  able to reach the prod DB (Tailscale/VPN is fine — this is the same host that already runs
+  the CD pipeline with those creds).
+- **Read-only on prod**: the clone only runs `pg_dump` against prod (no writes); all changes
+  land in the throwaway sidecar.
+- **Migrations**: if the branch is *behind* prod's migration history, `alembic upgrade head`
+  will fail (the DB is at a revision the branch doesn't know) — surfaced as a build failure.
+- **Cleanup**: previews persist until `down`/`cleanup`. Schedule a periodic `cleanup` job (e.g.
+  hourly) so stray previews don't accumulate on the host.
+- **Resources**: each preview holds an image + two containers; the sidecar DB is a full prod
+  clone, so watch host disk if many run at once.

--- a/helpers/preview/preview-env.sh
+++ b/helpers/preview/preview-env.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# preview-env.sh — spin up (or tear down) a disposable preview of the whole app for a git
+# branch, backed by a throwaway clone of the PROD database. Pure Docker; no k8s/Flux.
+#
+# Each preview = a dedicated docker network + a throwaway Postgres sidecar (cloned from
+# prod) + the app image built from the current checkout, published on a random high port.
+# Everything is labelled so it can be torn down cleanly.
+#
+# Usage:
+#   preview-env.sh up   <branch>          build + run; prints the URL and preview id
+#   preview-env.sh down <preview-id>      destroy one preview
+#   preview-env.sh list                   list running previews
+#   preview-env.sh cleanup [max_hours]    destroy previews older than max_hours (default 24)
+#
+# Source DB to clone FROM (prod) — provide EITHER a URL or the discrete params:
+#   SOURCE_DATABASE_URL      e.g. postgresql://user:pass@prod-host:5432/osmosmjerka
+#   -- or --
+#   SOURCE_DB_HOST, SOURCE_DB_PORT (default 5432), SOURCE_DB_USER, SOURCE_DB_PASSWORD,
+#   SOURCE_DB_NAME
+#
+# App admin secrets (same names the app + the main Jenkinsfile use):
+#   ADMIN_USERNAME, ADMIN_PASSWORD_HASH, ADMIN_SECRET_KEY
+#
+# Optional:
+#   PREVIEW_PG_IMAGE   postgres image for the sidecar/clone (default: postgres:18)
+#   PREVIEW_HOST       hostname printed in the URL (default: localhost)
+#   REPO_ROOT          path to the checked-out repo to build (default: git toplevel of CWD)
+#   PREVIEW_SKIP_MIGRATIONS=1   skip `alembic upgrade head` after cloning
+#
+set -euo pipefail
+
+LABEL="com.osmosmjerka.preview"
+PG_IMAGE="${PREVIEW_PG_IMAGE:-postgres:18}"
+DB_PASS="preview"
+DB_NAME="osmosmjerka"
+
+log()  { printf '\033[1;34m[preview]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[preview] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+sanitize() { echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g; s#^-+|-+$##g' | cut -c1-24; }
+require_env() { for v in "$@"; do [ -n "${!v:-}" ] || die "missing required env: $v"; done; }
+containers_of() { docker ps -aq --filter "label=$LABEL=$1"; }
+
+require_source() {
+  [ -n "${SOURCE_DATABASE_URL:-}" ] && return 0
+  for v in SOURCE_DB_HOST SOURCE_DB_USER SOURCE_DB_PASSWORD SOURCE_DB_NAME; do
+    [ -n "${!v:-}" ] || die "set SOURCE_DATABASE_URL, or all of SOURCE_DB_HOST/USER/PASSWORD/NAME"
+  done
+}
+
+pg_ready() {  # wait until a db container accepts connections
+  local c="$1"
+  for _ in $(seq 1 60); do docker exec "$c" pg_isready -U postgres >/dev/null 2>&1 && return 0; sleep 1; done
+  return 1
+}
+
+up() {
+  local branch="${1:?usage: up <branch>}"
+  [ "$branch" = "main" ] && die "refusing to create a preview for main"
+  require_source
+  require_env ADMIN_USERNAME ADMIN_PASSWORD_HASH ADMIN_SECRET_KEY
+
+  local root="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+  local id net db app img created
+  id="$(sanitize "$branch")-$RANDOM"
+  net="osmo-prev-net-$id"; db="osmo-prev-db-$id"; app="osmo-prev-app-$id"; img="osmo-preview:$id"
+  created="$(date +%s)"
+
+  # Best-effort cleanup if anything below fails.
+  trap 'log "up failed — cleaning up $id"; down "$id" >/dev/null 2>&1 || true' ERR
+
+  log "building app image from $root ($branch)…"
+  docker build -q --build-arg VERSION="preview-$id" -t "$img" "$root" >&2
+
+  log "creating network + throwaway postgres sidecar…"
+  docker network create "$net" >/dev/null
+  docker run -d --name "$db" --network "$net" -p 0:5432 \
+    --label "$LABEL=$id" --label "$LABEL.created=$created" --label "$LABEL.role=db" \
+    -e POSTGRES_PASSWORD="$DB_PASS" -e POSTGRES_DB="$DB_NAME" "$PG_IMAGE" >/dev/null
+  pg_ready "$db" || die "sidecar postgres did not become ready"
+  local db_host_port; db_host_port="$(docker port "$db" 5432/tcp | head -1 | sed 's/.*://')"
+
+  log "cloning prod DB → throwaway (via host network so Tailscale/VPN routes work)…"
+  # The clone runs on the HOST network so it can reach prod exactly like the Jenkins host
+  # can (incl. Tailscale), and restores into the sidecar via its published port. Source is
+  # given either as a URL or via standard PG* env (no URL-encoding pitfalls with passwords).
+  docker run --rm --network host \
+    -e SRC_URL="${SOURCE_DATABASE_URL:-}" \
+    -e PGHOST="${SOURCE_DB_HOST:-}" -e PGPORT="${SOURCE_DB_PORT:-5432}" \
+    -e PGUSER="${SOURCE_DB_USER:-}" -e PGPASSWORD="${SOURCE_DB_PASSWORD:-}" -e PGDATABASE="${SOURCE_DB_NAME:-}" \
+    -e DST="postgresql://postgres:$DB_PASS@127.0.0.1:$db_host_port/$DB_NAME" \
+    "$PG_IMAGE" bash -lc '
+      set -euo pipefail
+      if [ -n "$SRC_URL" ]; then
+        pg_dump --no-owner --no-acl "$SRC_URL" | psql -v ON_ERROR_STOP=1 -q "$DST"
+      else
+        pg_dump --no-owner --no-acl | psql -v ON_ERROR_STOP=1 -q "$DST"
+      fi' >&2
+
+  if [ "${PREVIEW_SKIP_MIGRATIONS:-0}" != "1" ]; then
+    log "applying branch migrations on top of the clone (alembic upgrade head)…"
+    # The clone carries prod's alembic_version, so this applies only the branch's NEW
+    # migrations — the whole point of a preview.
+    docker run --rm --network "$net" -w /app/backend \
+      -e POSTGRES_HOST="$db" -e POSTGRES_PORT=5432 -e POSTGRES_USER=postgres \
+      -e POSTGRES_PASSWORD="$DB_PASS" -e POSTGRES_DATABASE="$DB_NAME" \
+      "$img" alembic upgrade head >&2
+  fi
+
+  log "starting app…"
+  docker run -d --name "$app" --network "$net" -p 0:8085 \
+    --label "$LABEL=$id" --label "$LABEL.created=$created" --label "$LABEL.role=app" \
+    -e POSTGRES_HOST="$db" -e POSTGRES_PORT=5432 -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD="$DB_PASS" -e POSTGRES_DATABASE="$DB_NAME" \
+    -e ADMIN_USERNAME="$ADMIN_USERNAME" -e ADMIN_PASSWORD_HASH="$ADMIN_PASSWORD_HASH" \
+    -e ADMIN_SECRET_KEY="$ADMIN_SECRET_KEY" -e DEVELOPMENT_MODE=false \
+    "$img" >/dev/null
+
+  local port; port="$(docker port "$app" 8085/tcp | head -1 | sed 's/.*://')"
+  log "waiting for the app to answer…"
+  local ok=0
+  for _ in $(seq 1 60); do curl -sf "http://127.0.0.1:$port/" >/dev/null 2>&1 && { ok=1; break; }; sleep 1; done
+  [ "$ok" = 1 ] || log "warning: app not answering yet — check: docker logs $app"
+
+  trap - ERR
+  printf '\nPreview READY\n  id:   %s\n  url:  http://%s:%s\n  down: %s down %s\n\n' \
+    "$id" "${PREVIEW_HOST:-localhost}" "$port" "$0" "$id"
+}
+
+down() {
+  local id="${1:?usage: down <preview-id>}"
+  log "destroying preview $id…"
+  local cs; cs="$(containers_of "$id")"
+  [ -n "$cs" ] && docker rm -f $cs >/dev/null 2>&1 || true
+  docker network rm "osmo-prev-net-$id" >/dev/null 2>&1 || true
+  docker image rm -f "osmo-preview:$id" >/dev/null 2>&1 || true
+  log "preview $id destroyed"
+}
+
+list() {
+  printf '%-28s %-24s %s\n' "PREVIEW ID" "URL" "CREATED"
+  local c id port created
+  for c in $(docker ps -q --filter "label=$LABEL.role=app"); do
+    id="$(docker inspect --format "{{index .Config.Labels \"$LABEL\"}}" "$c")"
+    created="$(docker inspect --format "{{index .Config.Labels \"$LABEL.created\"}}" "$c")"
+    port="$(docker port "$c" 8085/tcp | head -1 | sed 's/.*://')"
+    printf '%-28s %-24s %s\n' "$id" "http://${PREVIEW_HOST:-localhost}:$port" "$(date -d "@$created" 2>/dev/null || echo "$created")"
+  done
+}
+
+cleanup() {
+  local max_hours="${1:-24}" cutoff; cutoff=$(( $(date +%s) - max_hours * 3600 ))
+  log "removing previews older than ${max_hours}h…"
+  local c id created
+  for c in $(docker ps -aq --filter "label=$LABEL.role=db"); do
+    id="$(docker inspect --format "{{index .Config.Labels \"$LABEL\"}}" "$c")"
+    created="$(docker inspect --format "{{index .Config.Labels \"$LABEL.created\"}}" "$c")"
+    if [ -n "$created" ] && [ "$created" -lt "$cutoff" ]; then down "$id"; fi
+  done
+}
+
+case "${1:-}" in
+  up)      shift; up "$@";;
+  down)    shift; down "$@";;
+  list)    list;;
+  cleanup) shift; cleanup "$@";;
+  *) echo "usage: $0 {up <branch> | down <preview-id> | list | cleanup [max_hours]}" >&2; exit 2;;
+esac


### PR DESCRIPTION
A **separate, manually-triggered** Jenkins pipeline for a quick "build a branch, click around, throw it away" preview. No k8s/Flux — just Docker on the Jenkins host.

## What it does (`up`)
1. `docker build` the app image from the target branch.
2. Start a throwaway `postgres:18` sidecar.
3. **Clone prod → sidecar** (`pg_dump | psql`, read-only on prod; runs over the host network so Tailscale/VPN routes work).
4. **`alembic upgrade head`** on the clone — applies only the branch's new migrations on top of prod's schema (test branch migrations safely).
5. Run the app on a **random high port**; print the URL + id + teardown command.

`down` / `list` / `cleanup` (TTL) round it out; everything is labelled `com.osmosmjerka.preview=<id>` for clean teardown.

## Files
- `helpers/preview/preview-env.sh` — up/down/list/cleanup
- `Jenkinsfile.preview` — the pipeline (matches the `Jenkinsfile` / `Jenkinsfile.promotion` naming)
- `helpers/preview/README.md` — setup, usage, caveats

## Credentials
**Reuses the CD pipeline's existing creds/env — no new secrets:** prod DB via `OSMOSMJERKA_POSTGRES_HOST/_PORT/_DATABASE` + `osmosmjerka-db-user`/`-db-password`; admin via `osmosmjerka-admin-username`/`-password-hash`/`-secret-key`.

## Testing
Verified end-to-end locally against a fake prod: build → clone (cloned data confirmed in the running app) → migrate → app on a random port → full teardown (containers + network + image). Guards (`up main` refused, missing env errors) and `cleanup` checked. Shell syntax clean.

## Notes
- Separate from the CD `Jenkinsfile` and prod `Jenkinsfile.promotion` — intentionally not on the release path.
- Schedule a periodic `cleanup` job so stray previews don't accumulate; each sidecar is a full prod clone (watch host disk).