### PR TITLE
ci: make preview pipeline agent configurable via PREVIEW_AGENT

### DIFF
--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -12,7 +12,10 @@
 //   env (global): OSMOSMJERKA_POSTGRES_HOST / _PORT / _DATABASE  (prod DB, the clone source)
 
 pipeline {
-  agent any
+  // Pin to a node via the global env var PREVIEW_AGENT (Manage Jenkins → System → Global
+  // properties → Environment variables). Empty/unset matches any agent, same as `agent any`.
+  // The chosen node must have Docker + reachability to the prod DB.
+  agent { label "${env.PREVIEW_AGENT ?: ''}" }
 
   parameters {
     choice(name: 'ACTION',  choices: ['up', 'down', 'list', 'cleanup'], description: 'What to do')

--- a/helpers/preview/README.md
+++ b/helpers/preview/README.md
@@ -78,6 +78,14 @@ It **reuses the same credentials/env as the CD `Jenkinsfile`** — no new secret
 For `up`, the job checks out the chosen branch into `./app` and builds from there, so the
 preview tooling stays on the branch the Jenkinsfile is loaded from.
 
+### Pinning the agent (`PREVIEW_AGENT`)
+
+By default the job runs on any agent. To pin it to a specific node — the one that has Docker
+and can reach the prod DB — set the global env var **`PREVIEW_AGENT`** (Manage Jenkins →
+System → Global properties → Environment variables) to that node's name or a label it has.
+Leave it unset for "any agent". (Done via env rather than a build parameter because the agent
+is selected before parameters are available.)
+
 ## Notes & caveats
 
 - **Prod reachability**: the clone step uses the host network, so the Jenkins host must be


### PR DESCRIPTION
Makes the branch-preview Jenkins pipeline's agent configurable per Jenkins instance instead of hardcoded.

- `Jenkinsfile.preview`: `agent any` → `agent { label "${env.PREVIEW_AGENT ?: ''}" }`.
  - Unset/empty ⇒ any agent (unchanged default).
  - Set `PREVIEW_AGENT` (Manage Jenkins → System → Global properties → Environment variables) to a node name/label to pin it to a node that has Docker + prod-DB reachability.
- Uses an env var rather than a build parameter because the agent is selected before parameters are available.
- README documents it.