### PR TITLE
ci: only clone/deploy staging on an actual release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,6 +222,12 @@ pipeline {
                 script {
                     if (!env.GITOPS_REPO?.trim() || env.GITOPS_REPO == 'null') {
                         echo 'Skipping GitOps deployment because GITOPS_REPO is not set.'
+                    } else if (env.IS_NEW_RELEASE != 'true') {
+                        // Only clone prod->staging + bump the staging image on an actual
+                        // release. Non-release main builds have no pushed image (the tag
+                        // would be v999.0.0-dev), so deploying them left staging pointing at
+                        // a phantom image AND reset its DB to prod's schema without migrating.
+                        echo 'Skipping GitOps deployment: not a new release (no image was built for this commit).'
                     } else if (env.TRIGGER_GITOPS_CD == 'true') {
                         withCredentials([sshUserPrivateKey(credentialsId: 'osmosmjerka-gitops-deploy-key', keyFileVariable: 'GITOPS_SSH_KEY')]) {
                         withEnv(["GIT_SSH_COMMAND=ssh -i ${env.GITOPS_SSH_KEY}"]) {


### PR DESCRIPTION
## Why
The staging outage today ("Failed to loading language set") was caused by this stage running on a **non-release** main build:

- The `TRIGGER_GITOPS_CD` param defaults to `true`, so `env.TRIGGER_GITOPS_CD` ended up `'true'` even for non-release builds.
- Those builds set `IMAGE_TAG=v999.0.0-dev` (never built/pushed) **and** still ran the Deploy stage: it fired the prod→staging DB clone (resetting staging to prod's older schema) and pointed the staging image at the phantom tag → `ImagePullBackOff`, and the running pod then queried a schema missing new columns (`language_sets.target_lang`).

## Change
Gate the Deploy stage on `IS_NEW_RELEASE == 'true'` — clone + staging image bump only happen for real releases (which have a real, pushed image). `TRIGGER_GITOPS_CD` remains an opt-out for releases.

Paired with a gitops-repo fix that makes the clone job run `alembic upgrade head` after cloning (so staging is always migrated to head).