### PR TITLE
fix: crossword state loss on navigation, mobile focus trap, and forfeit

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -106,6 +106,8 @@ function AppContent() {
   const [grid, setGrid] = useState([]);
   const [phrases, setPhrases] = useState([]);
   const [found, setFound] = useState([]);
+  // Crossword forfeit: the player gave up, answers were revealed, game is over-but-not-won.
+  const [forfeited, setForfeited] = useState(false);
   const [difficulty, setDifficulty] = useState("easy");
   const [gameType, setGameType] = useState(() => {
     // Initialize game type from URL
@@ -292,6 +294,7 @@ function AppContent() {
     setGrid([]);
     setPhrases([]);
     setFound([]);
+    setForfeited(false);
     resetSession();
   }, [resetSession]);
 
@@ -471,12 +474,24 @@ function AppContent() {
     setCurrentElapsedTime(0);
     currentElapsedTimeRef.current = 0;
     setFound([]);
+    setForfeited(false);
     setIsPaused(false);
 
     if (gridRef.current) {
       gridRef.current.clearHints();
     }
   }, [resetScoringState, gameType, phrases.length]);
+
+  // Give up on a crossword: reveal every answer and put the game into a finished state
+  // without crediting the unsolved phrases (no score / no mastery updates).
+  const handleForfeit = useCallback(() => {
+    if (gridRef.current?.revealAll) {
+      gridRef.current.revealAll();
+    }
+    setForfeited(true);
+    setHidePhrases(false);
+    setShowTranslations(true);
+  }, []);
 
   // Update hint count when game type changes (without refresh)
   useEffect(() => {
@@ -756,6 +771,8 @@ function AppContent() {
       trainingMode={trainingMode}
       onTrainingModeChange={setTrainingMode}
       onOpenReview={() => navigate("/review")}
+      forfeited={forfeited}
+      onForfeit={handleForfeit}
       notEnoughPhrases={notEnoughPhrases}
       notEnoughPhrasesMsg={notEnoughPhrasesMsg}
       isGridLoading={isGridLoading}

--- a/frontend/src/GameView.jsx
+++ b/frontend/src/GameView.jsx
@@ -1,6 +1,7 @@
 import { Box, Button, Stack } from "@mui/material";
 import AutorenewIcon from "@mui/icons-material/Autorenew";
 import PsychologyIcon from "@mui/icons-material/Psychology";
+import FlagOutlinedIcon from "@mui/icons-material/FlagOutlined";
 import {
   AllFoundMessage,
   CrosswordGrid,
@@ -50,6 +51,8 @@ export function GameView({
   trainingMode,
   onTrainingModeChange,
   onOpenReview,
+  forfeited,
+  onForfeit,
   notEnoughPhrases,
   notEnoughPhrasesMsg,
   isGridLoading,
@@ -254,6 +257,7 @@ export function GameView({
                 ref={gridRef}
                 grid={grid}
                 phrases={phrases}
+                found={found}
                 onPhraseComplete={onFound}
                 onPhraseWrong={() => {}}
                 disabled={allFound || isScreenTooSmall || isGridTooSmall}
@@ -356,6 +360,7 @@ export function GameView({
 
             {progressiveHintsEnabled &&
               phrases.length > 0 &&
+              !forfeited &&
               found.length < phrases.length && (
                 <HintButton
                   onHintRequest={onHintRequest}
@@ -390,6 +395,38 @@ export function GameView({
         )}
       </Box>
 
+      {/* Crossword: give up / forfeit — reveal the answers and end an unfinishable game */}
+      {gameType === "crossword" &&
+        phrases.length > 0 &&
+        !allFound &&
+        !forfeited &&
+        found.length < phrases.length && (
+          <Button
+            variant="outlined"
+            color="warning"
+            startIcon={<FlagOutlinedIcon />}
+            onClick={onForfeit}
+            disabled={isGridLoading || isGridTooSmall}
+          >
+            {t("crossword.give_up", "Give up")}
+          </Button>
+        )}
+
+      {gameType === "crossword" && forfeited && !allFound && (
+        <Stack spacing={1} sx={{ alignItems: "center" }}>
+          <Box sx={{ opacity: 0.8, textAlign: "center" }}>
+            {t("crossword.forfeited", "Answers revealed. Better luck next time!")}
+          </Box>
+          <Button
+            variant="contained"
+            startIcon={<AutorenewIcon />}
+            onClick={() => refreshPuzzle(selectedCategory, difficulty)}
+          >
+            {t("new_game")}
+          </Button>
+        </Stack>
+      )}
+
       {/* Mobile: Floating Actions */}
       {useMobileLayout && (
         <MobileFloatingActions
@@ -400,6 +437,7 @@ export function GameView({
           showHintButton={
             progressiveHintsEnabled &&
             phrases.length > 0 &&
+            !forfeited &&
             found.length < phrases.length
           }
           disabled={allFound || isGridTooSmall}

--- a/frontend/src/features/game/components/CrosswordGrid/CrosswordGrid.jsx
+++ b/frontend/src/features/game/components/CrosswordGrid/CrosswordGrid.jsx
@@ -6,6 +6,26 @@ import { useGridSize } from '../Grid/hooks';
 import CrosswordCell from './CrosswordCell';
 import './CrosswordGrid.css';
 
+// Rebuild the grid's internal input/completed state from the list of already-found phrases.
+// Used to repopulate the crossword after it remounts (e.g. navigating to the review sprint
+// and back), where App keeps `found` but the grid's own typed letters were lost.
+const buildSeedFromFound = (foundList, phraseList) => {
+    const inputs = {};
+    const completed = new Set();
+    (foundList || []).forEach((f) => {
+        const text = typeof f === 'string' ? f : f?.phrase;
+        const idx = phraseList.findIndex((p) => p.phrase === text);
+        if (idx === -1) return;
+        const p = phraseList[idx];
+        const clean = p.phrase.replace(/\s/g, '').toUpperCase();
+        p.coords.forEach(([r, c], i) => {
+            inputs[`${r},${c}`] = clean[i];
+        });
+        completed.add(idx);
+    });
+    return { inputs, completed };
+};
+
 /**
  * CrosswordGrid - Main crossword puzzle grid component
  * 
@@ -17,6 +37,7 @@ import './CrosswordGrid.css';
 const CrosswordGrid = forwardRef(({
     grid,                    // 2D array with cell metadata from backend
     phrases,                 // Array of phrase objects with coords, direction, start_number
+    found = [],              // Already-found phrases (to re-seed after remount)
     onPhraseComplete,        // Called when a phrase is correctly completed
     onPhraseWrong,           // Called when a filled phrase is incorrect
     disabled = false,
@@ -58,11 +79,20 @@ const CrosswordGrid = forwardRef(({
     const gridSize = grid.length;
     const cellSize = useGridSize(gridSize, isTouchDevice, useMobileLayout);
 
-    // Reset when grid changes
+    // Wrapper element, used for tap-outside-to-deselect (so mobile keyboards can be dismissed).
+    const containerRef = useRef(null);
+    // Latest `found` without making the reset effect depend on it (which would wipe in-progress
+    // typing every time a word is completed). Read only when the grid/phrases change.
+    const foundRef = useRef(found);
+    foundRef.current = found;
+
+    // Reset when the grid changes (new puzzle) but re-seed any phrases that were already found,
+    // so returning to a game in progress (e.g. from the review sprint) keeps the filled cells.
     useEffect(() => {
-        setUserInputs({});
+        const { inputs, completed } = buildSeedFromFound(foundRef.current, phrases);
+        setUserInputs(inputs);
         setActiveCell(null);
-        setCompletedPhrases(new Set());
+        setCompletedPhrases(completed);
         setWrongPhrases(new Set());
         setCurrentHintPhrase(null);
         setHintLevel(0);
@@ -71,7 +101,23 @@ const CrosswordGrid = forwardRef(({
         setTransientWrongCells(new Set());
         if (transientTimeoutRef.current) clearTimeout(transientTimeoutRef.current);
         if (blinkingTimeoutRef.current) clearTimeout(blinkingTimeoutRef.current);
-    }, [grid]);
+    }, [grid, phrases]);
+
+    // Tapping outside the grid deselects the active cell and blurs the focused input. On mobile
+    // this is the only way to dismiss the on-screen keyboard and scroll the page again.
+    useEffect(() => {
+        const handlePointerDown = (e) => {
+            if (containerRef.current && !containerRef.current.contains(e.target)) {
+                setActiveCell(null);
+                const el = document.activeElement;
+                if (el && typeof el.blur === 'function' && el.classList?.contains('crossword-input')) {
+                    el.blur();
+                }
+            }
+        };
+        document.addEventListener('pointerdown', handlePointerDown);
+        return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }, []);
 
     // Cleanup timeout on unmount
     useEffect(() => {
@@ -457,10 +503,28 @@ const CrosswordGrid = forwardRef(({
         }
     }, [phrases, completedPhrases, activeCell, currentDirection, userInputs, phraseHintLevels, showHint, onHintUsed]);
 
+    // Reveal every answer and lock the board (used when the player forfeits / gives up).
+    const revealAll = useCallback(() => {
+        const inputs = { ...userInputs };
+        const completed = new Set(completedPhrases);
+        phrases.forEach((p, idx) => {
+            const clean = p.phrase.replace(/\s/g, '').toUpperCase();
+            p.coords.forEach(([r, c], i) => {
+                inputs[`${r},${c}`] = clean[i];
+            });
+            completed.add(idx);
+        });
+        setUserInputs(inputs);
+        setCompletedPhrases(completed);
+        setWrongPhrases(new Set());
+        setActiveCell(null);
+    }, [userInputs, completedPhrases, phrases]);
+
     // Expose methods to parent
     useImperativeHandle(ref, () => ({
         showHint,
         showProgressiveHint,
+        revealAll,
         clearHints: () => {
             // Reset hint tracking state
             setCurrentHintPhrase(null);
@@ -491,7 +555,7 @@ const CrosswordGrid = forwardRef(({
         getCompletedCount: () => completedPhrases.size,
         getTotalPhrases: () => phrases.length,
         isAllComplete: () => completedPhrases.size === phrases.length,
-    }), [showHint, showProgressiveHint, completedPhrases, phrases, userInputs]);
+    }), [showHint, showProgressiveHint, revealAll, completedPhrases, phrases, userInputs]);
 
     // Early return for empty grid
     if (gridSize === 0) {
@@ -590,7 +654,7 @@ const CrosswordGrid = forwardRef(({
     const totalGridSize = gridSize * cellSize + (gridSize + 1) * 4;
 
     return (
-        <Box className="grid-wrapper">
+        <Box className="grid-wrapper" ref={containerRef}>
             <Box
                 className={`crossword-grid-container ${isDarkMode ? 'dark-mode' : 'light-mode'}`}
                 sx={{

--- a/frontend/src/features/game/components/CrosswordGrid/__tests__/CrosswordGrid.test.jsx
+++ b/frontend/src/features/game/components/CrosswordGrid/__tests__/CrosswordGrid.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ThemeProvider } from '@mui/material/styles';
 import { createTheme } from '@mui/material/styles';
 import CrosswordGrid from '../CrosswordGrid';
@@ -140,6 +140,82 @@ describe('CrosswordGrid', () => {
             // Note: Full toggle test requires checking direction state, 
             // which is internal. This verifies the cell is interactive.
             expect(cells).toBeTruthy();
+        });
+    });
+
+    describe('Re-seeding from found', () => {
+        // Non-blank inputs render row-major: [0]=B(0,2), [1]=C(1,1), [2]=A(1,2), [3]=T(1,3), [4]=T(2,2)
+        test('pre-fills and locks cells for already-found phrases', () => {
+            const { container } = renderGrid({ found: [samplePhrases[0]] }); // CAT already found
+            const inputs = container.querySelectorAll('.crossword-cell:not(.blank) input');
+            expect(inputs[1].value).toBe('C');
+            expect(inputs[2].value).toBe('A');
+            expect(inputs[3].value).toBe('T');
+            // Completed phrase cells are locked (disabled)
+            expect(inputs[1].disabled).toBe(true);
+            expect(inputs[3].disabled).toBe(true);
+            // The unrelated BAT-only cell (row2) stays empty and editable
+            expect(inputs[4].value).toBe('');
+            expect(inputs[4].disabled).toBe(false);
+        });
+
+        test('empty found leaves the board blank', () => {
+            const { container } = renderGrid({ found: [] });
+            const inputs = container.querySelectorAll('.crossword-cell:not(.blank) input');
+            inputs.forEach((i) => expect(i.value).toBe(''));
+        });
+    });
+
+    describe('Tap-outside to deselect (mobile scroll)', () => {
+        test('pointerdown outside the grid blurs the focused cell input', () => {
+            const { container } = renderGrid();
+            const input = container.querySelector('.crossword-cell:not(.blank) input');
+            act(() => input.focus());
+            expect(document.activeElement).toBe(input);
+
+            // Tap somewhere outside the grid (e.g. the page body)
+            act(() => {
+                document.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
+            });
+            expect(document.activeElement).not.toBe(input);
+        });
+
+        test('pointerdown inside the grid does not blur', () => {
+            const { container } = renderGrid();
+            const input = container.querySelector('.crossword-cell:not(.blank) input');
+            act(() => input.focus());
+
+            act(() => {
+                input.dispatchEvent(new window.Event('pointerdown', { bubbles: true }));
+            });
+            expect(document.activeElement).toBe(input);
+        });
+    });
+
+    describe('revealAll (forfeit)', () => {
+        test('fills and locks every cell when called via ref', () => {
+            const ref = React.createRef();
+            const { container } = render(
+                <ThemeProvider theme={theme}>
+                    <CrosswordGrid
+                        ref={ref}
+                        grid={createSampleGrid()}
+                        phrases={samplePhrases}
+                        onPhraseComplete={jest.fn()}
+                        onPhraseWrong={jest.fn()}
+                    />
+                </ThemeProvider>
+            );
+            const inputs = container.querySelectorAll('.crossword-cell:not(.blank) input');
+            inputs.forEach((i) => expect(i.value).toBe(''));
+
+            fireEvent.click(document.body); // no-op sanity
+            act(() => ref.current.revealAll());
+
+            inputs.forEach((i) => {
+                expect(i.value).not.toBe('');
+                expect(i.disabled).toBe(true);
+            });
         });
     });
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -910,6 +910,8 @@
     "hint_full_phrase": "Full phrase revealed",
     "hint_next_letter": "Next letter",
     "hint_validate": "Check letters",
-    "hint_reveal": "Reveal phrase"
+    "hint_reveal": "Reveal phrase",
+    "give_up": "Give up",
+    "forfeited": "Answers revealed. Better luck next time!"
   }
 }

--- a/frontend/src/locales/hr.json
+++ b/frontend/src/locales/hr.json
@@ -911,6 +911,8 @@
     "hint_full_phrase": "Cijela fraza otkrivena",
     "hint_next_letter": "Sljedeće slovo",
     "hint_validate": "Provjeri slova",
-    "hint_reveal": "Otkrij frazu"
+    "hint_reveal": "Otkrij frazu",
+    "give_up": "Predaj se",
+    "forfeited": "Odgovori otkriveni. Više sreće drugi put!"
   }
 }

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -916,6 +916,8 @@
     "hint_full_phrase": "Cała fraza odkryta",
     "hint_next_letter": "Następna litera",
     "hint_validate": "Sprawdź litery",
-    "hint_reveal": "Odkryj frazę"
+    "hint_reveal": "Odkryj frazę",
+    "give_up": "Poddaj się",
+    "forfeited": "Odpowiedzi odsłonięte. Powodzenia następnym razem!"
   }
 }


### PR DESCRIPTION
## What & why

Three crossword-mode UX bugs reported during play:

### 1. Board cleared when opening the review sprint mid-game
The crossword's typed letters and completed-phrase state lived only inside `CrosswordGrid` and were lost when the component unmounted (navigating to `/review`) and remounted — App's `found` list survived but the grid never rebuilt from it. Now `CrosswordGrid` re-seeds its filled + locked cells from the already-found phrases on mount/grid-change (via a ref so in-progress typing is never wiped).

### 2. Mobile: cursor locked in a cell, couldn't deselect or scroll
Added a document-level `pointerdown` listener — tapping anywhere outside the grid clears the active cell and blurs the input, so the on-screen keyboard dismisses and the page scrolls again.

### 3. No way to forfeit an unfinishable crossword
Added a **Give up** button (crossword only, shown while phrases remain). It reveals every answer via a new `revealAll()` grid method and ends the game **without crediting the unsolved words** (no score / mastery inflation). Shows a 'answers revealed' message + New game; hints hide. Added `crossword.give_up` / `crossword.forfeited` in en/pl/hr.

## Testing
- `eslint` clean, `vite build` OK, **447 frontend tests pass** (5 new CrosswordGrid tests: re-seed fills/locks found cells, empty stays blank, tap-outside blur ×2, revealAll).
- Verified end-to-end in a real browser (Firefox/Playwright) against the real backend + Postgres: 9/9 checks including all three fixes.