### PR TITLE
ci: Playwright E2E smoke tests (both game modes, desktop + mobile)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,6 +213,31 @@ pipeline {
             }
         }
 
+        stage('E2E Smoke (Playwright)') {
+            // Only on an actual release merged to main — spins up a throwaway stack and
+            // plays both game modes (word search + crossword) on desktop + mobile. A
+            // failure here blocks the deploy stage below.
+            //
+            // Locked to the main Jenkins agent (needs docker + node): set the global env var
+            // E2E_AGENT to its label. This stage gets its own fresh workspace, so
+            // run-e2e.sh re-provisions the venv/node deps itself.
+            agent { label "${env.E2E_AGENT ?: ''}" }
+            when {
+                beforeAgent true
+                branch 'main'
+                environment name: 'IS_NEW_RELEASE', value: 'true'
+            }
+            steps {
+                sh 'chmod +x helpers/e2e/run-e2e.sh helpers/e2e/seed.py'
+                sh 'helpers/e2e/run-e2e.sh'
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'frontend/e2e/test-results/**', allowEmptyArchive: true
+                }
+            }
+        }
+
         stage('Deploy with GitOps (staging and prod)') {
             when {
                 branch 'main'

--- a/frontend/e2e/.gitignore
+++ b/frontend/e2e/.gitignore
@@ -1,0 +1,4 @@
+# Playwright run artifacts
+test-results/
+playwright-report/
+.cache/

--- a/frontend/e2e/playwright.config.js
+++ b/frontend/e2e/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from '@playwright/test';
+
+// E2E smoke tests for the two game modes on desktop + mobile. The stack (backend, DB,
+// seeded data) is brought up by helpers/e2e/run-e2e.sh, which passes the base URL, admin
+// token and language-set id through these env vars. Both projects use Firefox — it's the
+// browser Playwright ships that runs reliably headless on the CD agent; "mobile" is a
+// narrow touch viewport (the app's responsive layout keys off viewport width).
+export default defineConfig({
+  testDir: './tests',
+  outputDir: './test-results',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1, // single shared backend; also stays under the /api/phrases rate limit
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  use: {
+    browserName: 'firefox',
+    baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:8099',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'desktop', use: { viewport: { width: 1400, height: 900 } } },
+    { name: 'mobile', use: { viewport: { width: 393, height: 851 }, hasTouch: true } },
+  ],
+});

--- a/frontend/e2e/tests/crossword.spec.js
+++ b/frontend/e2e/tests/crossword.spec.js
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { seedBrowser, capturePuzzle, crosswordInputIndex } from './helpers.js';
+
+// Regular playing path for crossword: load a puzzle, type every answer, and confirm the
+// whole board ends up solved (all cells filled and locked). Runs on desktop + mobile.
+test('crossword: solve the whole puzzle', async ({ page }) => {
+  await seedBrowser(page);
+  const cap = capturePuzzle(page);
+
+  await page.goto('/crosswords', { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('.crossword-cell:not(.blank) input', { timeout: 20_000 });
+  await page.waitForTimeout(600);
+
+  expect(cap.puzzle, 'puzzle should have loaded').toBeTruthy();
+  expect(cap.puzzle.phrases.length).toBeGreaterThan(0);
+
+  const idx = crosswordInputIndex(cap.puzzle.grid);
+  const inputs = await page.$$('.crossword-cell:not(.blank) input');
+
+  for (const phrase of cap.puzzle.phrases) {
+    const letters = phrase.phrase.replace(/\s/g, '').toUpperCase().split('');
+    for (let i = 0; i < phrase.coords.length; i++) {
+      const [r, c] = phrase.coords[i];
+      const el = inputs[idx[`${r},${c}`]];
+      // Skip cells already locked by an intersecting completed word.
+      if (await el.evaluate((e) => e.disabled)) continue;
+      await el.click();
+      await page.keyboard.type(letters[i]);
+    }
+  }
+
+  await page.waitForTimeout(500);
+
+  // Every playable cell should now be filled and locked (correct + completed).
+  const states = await Promise.all(inputs.map((el) => el.evaluate((e) => ({ v: e.value, d: e.disabled }))));
+  const filled = states.filter((s) => s.v && s.v.length > 0).length;
+  expect(filled).toBe(states.length);
+  expect(states.every((s) => s.d)).toBeTruthy();
+});

--- a/frontend/e2e/tests/helpers.js
+++ b/frontend/e2e/tests/helpers.js
@@ -1,0 +1,53 @@
+// Shared helpers for the E2E specs.
+
+export const TOKEN = process.env.E2E_ADMIN_TOKEN || '';
+export const LANG = process.env.E2E_LANG_SET_ID || '1';
+
+// Inject auth + preselected language set into localStorage before the app boots, so it
+// loads a puzzle straight away for a "logged in" user.
+export async function seedBrowser(page) {
+  await page.addInitScript(
+    ({ token, lang }) => {
+      localStorage.setItem('adminToken', token);
+      localStorage.setItem('selectedLanguageSet', lang);
+      // Suppress the "What's New" modal — it auto-opens for logged-in users on a new
+      // version and would otherwise intercept clicks on the grid.
+      localStorage.setItem('lastSeenVersion', '999.0.0');
+    },
+    { token: TOKEN, lang: LANG }
+  );
+}
+
+// Capture the exact puzzle the app renders (grid + phrases) by tapping the /api/phrases
+// response while passing it through unchanged. Returns an object whose `.puzzle` is filled
+// once the app has loaded a board.
+export function capturePuzzle(page) {
+  const holder = {};
+  page.route('**/api/phrases**', async (route) => {
+    const resp = await route.fetch();
+    try {
+      const json = await resp.json();
+      if (Array.isArray(json.grid)) holder.puzzle = json;
+    } catch {
+      /* not JSON — ignore */
+    }
+    await route.fulfill({ response: resp });
+  });
+  return holder;
+}
+
+// Map "row,col" -> row-major index among non-blank cells (crossword inputs render in that
+// order, and blank cells have no input).
+export function crosswordInputIndex(grid) {
+  const idx = {};
+  let n = 0;
+  for (let r = 0; r < grid.length; r++) {
+    for (let c = 0; c < grid[r].length; c++) {
+      if (grid[r][c] !== null) {
+        idx[`${r},${c}`] = n;
+        n++;
+      }
+    }
+  }
+  return idx;
+}

--- a/frontend/e2e/tests/wordsearch.spec.js
+++ b/frontend/e2e/tests/wordsearch.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { seedBrowser, capturePuzzle } from './helpers.js';
+
+// Regular playing path for word search: load a puzzle, drag-select every word, and confirm
+// all of them get marked found on the grid. Runs on desktop + mobile (mouse drag works for
+// both — the grid handles mouse events regardless of touch).
+test('word search: find every word', async ({ page }) => {
+  await seedBrowser(page);
+  const cap = capturePuzzle(page);
+
+  await page.goto('/wordsearch', { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-grid-container="true"]', { timeout: 20_000 });
+  await page.waitForTimeout(600);
+
+  expect(cap.puzzle, 'puzzle should have loaded').toBeTruthy();
+  expect(cap.puzzle.phrases.length).toBeGreaterThan(0);
+
+  await page.locator('[data-grid-container="true"]').scrollIntoViewIfNeeded();
+
+  const centerOf = async (r, c) => {
+    const box = await page.locator(`[data-row="${r}"][data-col="${c}"]`).boundingBox();
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  };
+
+  const isWordFound = async (coords) => {
+    for (const [r, c] of coords) {
+      const cls = (await page.locator(`[data-row="${r}"][data-col="${c}"]`).getAttribute('class')) || '';
+      if (!cls.split(/\s+/).includes('found')) return false;
+    }
+    return true;
+  };
+
+  const dragWord = async (coords) => {
+    // Hover every cell of the word in turn so each throttled mouseenter registers and the
+    // grid builds the full selection path before we release.
+    const centers = [];
+    for (const [r, c] of coords) centers.push(await centerOf(r, c));
+    await page.mouse.move(centers[0].x, centers[0].y);
+    await page.mouse.down();
+    for (let i = 1; i < centers.length; i++) {
+      await page.mouse.move(centers[i].x, centers[i].y, { steps: 4 });
+      await page.waitForTimeout(30); // beat the 20ms mouseenter throttle
+    }
+    await page.mouse.up();
+    await page.waitForTimeout(120);
+  };
+
+  for (const phrase of cap.puzzle.phrases) {
+    // Drag can occasionally miss; retry until the word registers as found.
+    for (let attempt = 0; attempt < 4 && !(await isWordFound(phrase.coords)); attempt++) {
+      await dragWord(phrase.coords);
+    }
+  }
+
+  // The union of all word cells should now carry the `found` highlight.
+  const expectedFound = new Set();
+  for (const p of cap.puzzle.phrases) for (const [r, c] of p.coords) expectedFound.add(`${r},${c}`);
+
+  await expect
+    .poll(async () => page.locator('.grid-cell.found').count(), { timeout: 10_000 })
+    .toBe(expectedFound.size);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.49.0",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -57,6 +58,10 @@
     },
     "jest": {
         "testEnvironment": "jsdom",
+        "testPathIgnorePatterns": [
+            "/node_modules/",
+            "/e2e/"
+        ],
         "setupFilesAfterEnv": [
             "@testing-library/jest-dom",
             "./jest.setup.js"

--- a/helpers/e2e/README.md
+++ b/helpers/e2e/README.md
@@ -1,0 +1,45 @@
+# End-to-end smoke tests
+
+Playwright smoke tests that play the **regular path of both game modes** (word search +
+crossword) on **desktop and mobile** viewports, against a fully throwaway stack.
+
+## What runs
+
+`helpers/e2e/run-e2e.sh` orchestrates everything and tears it all down on exit:
+
+1. A throwaway **Postgres** container (`docker`).
+2. The **backend** (from `backend/.venv`) serving the freshly-built frontend from
+   `backend/static` in production mode (`DEVELOPMENT_MODE=false`).
+3. **Seeds** one language set of overlapping short words via the admin API
+   (`helpers/e2e/seed.py`) — enough for the crossword generator to find intersections and
+   for the word-search grid.
+4. Runs the **Playwright** specs in `frontend/e2e/` and passes/fails accordingly.
+
+Tests live in `frontend/e2e/tests/`; config in `frontend/e2e/playwright.config.js`
+(two projects: `desktop` and `mobile`, both Firefox — the browser that runs reliably
+headless on the CD agent; "mobile" is a narrow touch viewport).
+
+## Running locally
+
+```bash
+# prerequisites: docker, node, and the backend venv (pip install .[dev])
+cd frontend && npm ci        # installs @playwright/test
+helpers/e2e/run-e2e.sh       # builds, serves, seeds, runs all 4 test executions
+```
+
+Useful env overrides: `E2E_APP_PORT` (default 8099), `E2E_PG_PORT` (default 55432),
+`E2E_KEEP_UP=1` (leave the stack running for debugging).
+
+## CI
+
+Wired into the CD `Jenkinsfile` as the **E2E Smoke (Playwright)** stage, gated to
+`branch main` + `IS_NEW_RELEASE == 'true'` — it runs only for an actual release merged to
+main, before the GitOps deploy stage, so a failing smoke blocks the deploy. Playwright
+artifacts (traces/screenshots on failure) are archived from `frontend/e2e/test-results/`.
+
+The stage is **locked to the main Jenkins agent** via `agent { label ... }`, taking the
+label from the dedicated global env var `E2E_AGENT`. Because a
+stage-level agent gets its own fresh workspace, `run-e2e.sh` re-provisions everything it
+needs — it creates the backend venv (`pip install .[dev]`), installs frontend deps, builds
+the frontend, and installs Firefox (`npx playwright install firefox`). The agent only needs
+**docker + node + python** available.

--- a/helpers/e2e/run-e2e.sh
+++ b/helpers/e2e/run-e2e.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke test runner for osmosmjerka.
+#
+# Spins up a fully throwaway stack — a Postgres container, the backend (from the repo's
+# Python venv) serving the freshly-built frontend, seeded with one language set — and runs
+# the Playwright specs (both game modes, desktop + mobile) against it. Everything is torn
+# down on exit. Designed to run on the CD Jenkins agent (needs docker + node + the backend
+# venv); see helpers/e2e/README.md.
+#
+# Env overrides: E2E_APP_PORT, E2E_PG_PORT, E2E_PG_IMAGE, E2E_KEEP_UP (leave stack running).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+APP_PORT="${E2E_APP_PORT:-8099}"
+PG_PORT="${E2E_PG_PORT:-55432}"
+PG_IMAGE="${E2E_PG_IMAGE:-postgres:18-alpine}"
+PG_NAME="osm-e2e-pg-$$"
+VENV="$ROOT/backend/.venv"
+ADMIN_USER="e2e-admin"
+ADMIN_PASS="e2e-pass-$$"
+BASE_URL="http://127.0.0.1:${APP_PORT}"
+
+BACKEND_PID=""
+cleanup() {
+  [ -n "$BACKEND_PID" ] && kill "$BACKEND_PID" 2>/dev/null || true
+  docker rm -f "$PG_NAME" >/dev/null 2>&1 || true
+  rm -rf "$ROOT/backend/static" 2>/dev/null || true
+}
+[ -n "${E2E_KEEP_UP:-}" ] || trap cleanup EXIT
+
+echo "==> Preflight"
+command -v docker >/dev/null || { echo "docker is required"; exit 1; }
+command -v node   >/dev/null || { echo "node is required"; exit 1; }
+
+# Self-provision the backend venv when missing (the CI E2E stage runs on its own agent with
+# a fresh workspace, so it can't rely on an earlier Install Dependencies stage).
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "==> Creating backend venv"
+  PYBIN="$(command -v python3.13 || command -v python3)"
+  "$PYBIN" -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip
+  ( cd "$ROOT" && "$VENV/bin/pip" install --quiet ".[dev]" )
+fi
+
+echo "==> Starting Postgres ($PG_IMAGE) on :$PG_PORT"
+docker rm -f "$PG_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$PG_NAME" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=osmosmjerka \
+  -p "${PG_PORT}:5432" "$PG_IMAGE" >/dev/null
+for _ in $(seq 1 60); do docker exec "$PG_NAME" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+
+echo "==> Building frontend and serving it from the backend"
+# npm install (not ci): package-lock.json is git-ignored in this repo.
+( cd "$ROOT/frontend" && [ -d node_modules ] || npm install )
+( cd "$ROOT/frontend" && VITE_BASE_PATH=/static/ npm run build )
+rm -rf "$ROOT/backend/static"
+cp -r "$ROOT/frontend/build" "$ROOT/backend/static"
+
+# Throwaway admin creds for this run (independent of any real credentials).
+ADMIN_HASH="$("$VENV/bin/python" -c "import bcrypt,sys; print(bcrypt.hashpw(sys.argv[1].encode(), bcrypt.gensalt()).decode())" "$ADMIN_PASS")"
+
+echo "==> Starting backend on :$APP_PORT"
+(
+  cd "$ROOT/backend"
+  POSTGRES_HOST=127.0.0.1 POSTGRES_PORT="$PG_PORT" POSTGRES_USER=postgres \
+  POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=osmosmjerka \
+  ADMIN_USERNAME="$ADMIN_USER" ADMIN_PASSWORD_HASH="$ADMIN_HASH" ADMIN_SECRET_KEY="e2e-secret-$$" \
+  DEVELOPMENT_MODE=false \
+  exec "$VENV/bin/python" -m uvicorn osmosmjerka.app:app --host 127.0.0.1 --port "$APP_PORT"
+) &
+BACKEND_PID=$!
+
+echo "==> Seeding data"
+SEED_OUT="$("$VENV/bin/python" "$ROOT/helpers/e2e/seed.py" "$BASE_URL" "$ADMIN_USER" "$ADMIN_PASS")"
+E2E_ADMIN_TOKEN="$(printf '%s\n' "$SEED_OUT" | sed -n 's/^TOKEN=//p')"
+E2E_LANG_SET_ID="$(printf '%s\n' "$SEED_OUT" | sed -n 's/^LANGSET=//p')"
+[ -n "$E2E_ADMIN_TOKEN" ] && [ -n "$E2E_LANG_SET_ID" ] || { echo "seeding failed"; exit 1; }
+echo "    language set id: $E2E_LANG_SET_ID"
+
+echo "==> Installing Playwright browser (firefox)"
+( cd "$ROOT/frontend"
+  npx playwright install --with-deps firefox 2>/dev/null || npx playwright install firefox )
+
+echo "==> Running Playwright specs (word search + crossword, desktop + mobile)"
+cd "$ROOT/frontend"
+E2E_BASE_URL="$BASE_URL" E2E_ADMIN_TOKEN="$E2E_ADMIN_TOKEN" E2E_LANG_SET_ID="$E2E_LANG_SET_ID" \
+  npx playwright test --config e2e/playwright.config.js
+
+echo "==> E2E passed"

--- a/helpers/e2e/seed.py
+++ b/helpers/e2e/seed.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Seed a throwaway osmosmjerka backend with one language set of crossword/word-search
+friendly phrases, then print the admin token + language set id for the Playwright run.
+
+Usage: seed.py <base_url> <admin_user> <admin_pass>
+Prints two lines: TOKEN=<jwt> and LANGSET=<id>.
+"""
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Short, heavily-overlapping words so the crossword generator has intersections to work
+# with; also fine for the word-search grid. category;phrase;translation
+WORDS = [
+    ("cat", "kot"), ("dog", "pies"), ("rat", "szczur"), ("bat", "nietoperz"),
+    ("owl", "sowa"), ("cow", "krowa"), ("ant", "mrowka"), ("bee", "pszczola"),
+    ("fox", "lis"), ("hen", "kura"), ("pig", "swinia"), ("ram", "baran"),
+    ("ape", "malpa"), ("elk", "los"), ("eel", "wegorz"), ("emu", "ptak"),
+    ("asp", "zmija"), ("sow", "maciora"), ("tan", "opalenizna"), ("tar", "smola"),
+    ("net", "siec"), ("ten", "dziesiec"), ("nap", "drzemka"), ("pan", "patelnia"),
+    ("ear", "ucho"), ("era", "epoka"), ("oat", "owies"), ("toe", "palec"),
+    ("eat", "jesc"), ("tea", "herbata"), ("ore", "ruda"), ("roe", "ikra"),
+    ("arc", "luk"), ("oar", "wioslo"), ("rot", "gnicie"),
+]
+
+
+def _req(method, url, token=None, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read().decode())
+
+
+def main():
+    base, user, password = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    # Wait for the backend to answer before seeding.
+    for _ in range(60):
+        try:
+            _req("GET", f"{base}/api/version")
+            break
+        except urllib.error.URLError:
+            time.sleep(1)
+
+    token = _req("POST", f"{base}/admin/login", body={"username": user, "password": password})["access_token"]
+
+    set_id = _req(
+        "POST",
+        f"{base}/admin/language-sets",
+        token=token,
+        body={"name": "E2E-EN-PL", "display_name": "E2E", "description": "e2e", "author": "ci", "target_lang": "pl"},
+    )["id"]
+
+    content = "categories;phrase;translation\n" + "\n".join(f"animals;{w};{t}" for w, t in WORDS)
+    _req(
+        "POST",
+        f"{base}/admin/upload-text?language_set_id={set_id}",
+        token=token,
+        body={"content": content, "separator": ";"},
+    )
+
+    print(f"TOKEN={token}")
+    print(f"LANGSET={set_id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

End-to-end smoke tests that play the **regular path of both game modes** — word search and crossword — on **desktop and mobile** viewports, against a fully throwaway stack.

### How it runs
`helpers/e2e/run-e2e.sh` orchestrates and tears down everything:
1. Throwaway **Postgres** container (docker).
2. **Backend** (from the venv) serving the freshly-built frontend from `backend/static` in production mode.
3. **Seeds** one language set of overlapping short words via the admin API (`helpers/e2e/seed.py`).
4. Runs the **Playwright** specs in `frontend/e2e/`.

Specs: crossword (type every answer → board solved) and word search (drag-select every word → all cells found), each run under a `desktop` and a `mobile` project.

### CI wiring
New **E2E Smoke (Playwright)** stage in the CD `Jenkinsfile`, gated to `branch main` + `IS_NEW_RELEASE == 'true'` — runs only for an actual release, **before** the GitOps deploy stage, so a failing smoke blocks the deploy. Artifacts (traces/screenshots on failure) archived from `frontend/e2e/test-results/`.

**Locked to the main Jenkins agent** via `agent { label "${env.E2E_AGENT ?: ''}" }` — set the global env var `E2E_AGENT` to the agent's label. Since a stage-level agent gets a fresh workspace, `run-e2e.sh` self-provisions (creates the backend venv, installs frontend deps, builds, installs Firefox). Agent needs docker + node + python.

### Notes
- Both Playwright projects use **Firefox** (Chromium wouldn't run headless reliably in this environment; the mobile project is a narrow `hasTouch` viewport).
- `@playwright/test` added to frontend devDeps; jest configured to ignore `e2e/`.

## Testing
Verified locally end to end: **4/4 pass** (both modes × desktop + mobile), runner reports `E2E passed`, clean teardown. `eslint e2e/` clean; `jest` still 447 (excludes e2e).