### PR TITLE
feat: TTS play button in admin browse records

### DIFF
--- a/frontend/src/features/admin/components/BrowseRecords/AdminTable.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/AdminTable.jsx
@@ -107,7 +107,10 @@ export default function AdminTable({
     isSavingNewRow = false,
     canAddNewRow = true,
     categoryOptions = [],
-    compactMode = false
+    compactMode = false,
+    targetLang = null,
+    ttsEnabled = false,
+    ttsRefreshKey = 0
 }) {
     const { t } = useTranslation();
     const [editDialog, setEditDialog] = useState({ open: false, row: null });
@@ -391,10 +394,12 @@ export default function AdminTable({
                 cell: info => {
                     const row = info.row.original;
                     return (
-                        <TableRowActions 
+                        <TableRowActions
                             row={row}
                             onEdit={handleOpenEditDialog}
                             onDelete={handleDelete}
+                            targetLang={targetLang}
+                            ttsEnabled={ttsEnabled}
                         />
                     );
                 }
@@ -433,8 +438,8 @@ export default function AdminTable({
         }
 
         return baseColumns;
-    }, [t, minColumnWidths, batchMode, isAllSelected, isIndeterminate, handleSelectAll, 
-        selectedRows, handleRowCheckboxChange]);
+    }, [t, minColumnWidths, batchMode, isAllSelected, isIndeterminate, handleSelectAll,
+        selectedRows, handleRowCheckboxChange, targetLang, ttsEnabled, ttsRefreshKey]);
 
     // Create table instance
     const table = useReactTable({

--- a/frontend/src/features/admin/components/BrowseRecords/BrowseRecordsView.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/BrowseRecordsView.jsx
@@ -28,7 +28,10 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import { useTranslation } from 'react-i18next';
+import { useSystemPreferences } from '../../../../hooks/useSystemPreferences';
+import VoiceManager from '../../../game/components/Review/VoiceManager';
 import AdminTable from './AdminTable';
 import BatchOperationDialog from './BatchOperationDialog';
 import BatchOperationsToolbar from './BatchOperationsToolbar';
@@ -118,6 +121,16 @@ const BrowseRecordsView = ({
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const [adminControlsOpen, setAdminControlsOpen] = useState(!isMobile);
+
+    // TTS: the selected language set's target language drives which in-browser voice speaks
+    // the phrases. Bumping ttsRefreshKey after the voice manager closes re-renders the table
+    // so freshly-downloaded voices light up the per-row play buttons.
+    const { ttsEnabled } = useSystemPreferences();
+    const [voiceMgrOpen, setVoiceMgrOpen] = useState(false);
+    const [ttsRefreshKey, setTtsRefreshKey] = useState(0);
+    const selectedSet = languageSets.find((s) => String(s.id) === String(selectedLanguageSetId));
+    const targetLang = selectedSet?.target_lang || null;
+    const showTts = ttsEnabled && !!targetLang;
 
     const handlePageSizeChange = (newLimit) => {
         setLimit(newLimit);
@@ -252,6 +265,21 @@ const BrowseRecordsView = ({
                 </Stack>
             </Collapse>
 
+            {/* TTS voice packs for the selected set's language (download once, then each row
+                gets a play button) */}
+            {showTts && (
+                <Box sx={{ mb: 2 }}>
+                    <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<VolumeUpIcon fontSize="inherit" />}
+                        onClick={() => setVoiceMgrOpen(true)}
+                    >
+                        {t('review.voices', 'Voice packs')}
+                    </Button>
+                </Box>
+            )}
+
             {(currentUser && selectedLanguageSetId) || ignoredCategoriesCount > 0 ? (
                 <Collapse in={showIgnoredCategories} timeout="auto">
                     <Box sx={{ mt: 1 }}>
@@ -376,6 +404,9 @@ const BrowseRecordsView = ({
                     canAddNewRow={canAddNewRow}
                     categoryOptions={categories}
                     compactMode={isLayoutCompact}
+                    targetLang={targetLang}
+                    ttsEnabled={ttsEnabled}
+                    ttsRefreshKey={ttsRefreshKey}
                 />
                 <Fade in={loading} unmountOnExit>
                     <Box
@@ -441,6 +472,15 @@ const BrowseRecordsView = ({
                 operation={batchResult.operation}
                 result={batchResult.result}
             />
+
+            {targetLang && (
+                <VoiceManager
+                    open={voiceMgrOpen}
+                    onClose={() => { setVoiceMgrOpen(false); setTtsRefreshKey((k) => k + 1); }}
+                    lang={targetLang}
+                    t={t}
+                />
+            )}
 
             {/* Status Notifications */}
             <Snackbar

--- a/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
@@ -3,16 +3,24 @@ import { Box, Button } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useTranslation } from 'react-i18next';
+import ListenButton from '../../../game/components/Review/ListenButton';
 
-export default function TableRowActions({ 
+export default function TableRowActions({
     row,
     onEdit,
-    onDelete
+    onDelete,
+    targetLang = null,
+    ttsEnabled = false
 }) {
     const { t } = useTranslation();
-    
+
     return (
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', justifyContent: 'center' }}>
+            {/* Speak the phrase with the language set's in-browser voice. Renders only when a
+                voice for the target language is installed (ListenButton self-gates). */}
+            {ttsEnabled && targetLang && (
+                <ListenButton text={row.phrase} lang={targetLang} t={t} size="medium" />
+            )}
             <Button
                 size="small"
                 onClick={() => onEdit(row)}

--- a/frontend/src/features/admin/components/BrowseRecords/__tests__/BrowseRecordsView.test.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/__tests__/BrowseRecordsView.test.jsx
@@ -9,6 +9,10 @@ jest.mock('../BatchOperationDialog', () => () => <div data-testid="batch-operati
 jest.mock('../BatchResultDialog', () => () => <div data-testid="batch-result-dialog" />);
 jest.mock('../BatchOperationsToolbar', () => () => <div data-testid="batch-toolbar" />);
 jest.mock('../PaginationControls', () => () => <div data-testid="pagination-controls" />);
+jest.mock('../../../../game/components/Review/VoiceManager', () => () => <div data-testid="voice-manager" />);
+jest.mock('../../../../../hooks/useSystemPreferences', () => ({
+    useSystemPreferences: () => ({ ttsEnabled: true, scoringEnabled: true, progressiveHintsEnabled: true }),
+}));
 
 // Mock react-i18next
 jest.mock('react-i18next', () => ({
@@ -93,6 +97,22 @@ describe('BrowseRecordsView', () => {
         // Check language set options are present (in DOM but hidden until clicked for Select)
         // However, MUI Select options are not in DOM usually until clicked.
         // We can check the value of the input.
+    });
+
+    test('shows the Voice packs button only when the selected set has a target language', () => {
+        // Default mock sets have no target_lang -> no button
+        const { rerender } = render(<BrowseRecordsView {...mockProps} />);
+        expect(screen.queryByText('review.voices')).not.toBeInTheDocument();
+
+        // A set with target_lang selected -> button appears
+        rerender(
+            <BrowseRecordsView
+                {...mockProps}
+                languageSets={[{ id: 1, display_name: 'Set 1', target_lang: 'pl' }]}
+                selectedLanguageSetId={1}
+            />
+        );
+        expect(screen.getByText('review.voices')).toBeInTheDocument();
     });
 
     test('renders ignored categories section', () => {

--- a/frontend/src/features/admin/components/BrowseRecords/__tests__/TableRowActions.test.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/__tests__/TableRowActions.test.jsx
@@ -3,6 +3,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import TableRowActions from '../TableRowActions';
 import { withI18n } from '../../../../../testUtils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { installedVoiceForLang, speak } from '../../../../../hooks/localTts';
+
+// ListenButton (used for the play action) reads installed voices + speaks through localTts.
+jest.mock('../../../../../hooks/localTts', () => ({
+    installedVoiceForLang: jest.fn(() => 'pl_PL-gosia-medium'),
+    speak: jest.fn(),
+}));
 
 // Create a test theme
 const theme = createTheme({
@@ -62,5 +69,35 @@ describe('TableRowActions', () => {
         
     fireEvent.click(screen.getByRole('button', { name: /delete/i }));
         expect(mockDelete).toHaveBeenCalledWith(testRow);
+    });
+
+    describe('TTS play button', () => {
+        const phraseRow = { id: 2, phrase: 'kot', translation: 'cat' };
+        beforeEach(() => {
+            installedVoiceForLang.mockReturnValue('pl_PL-gosia-medium');
+            speak.mockClear();
+        });
+
+        test('not shown by default (ttsEnabled false)', () => {
+            renderWithTheme(<TableRowActions row={phraseRow} onEdit={() => {}} onDelete={() => {}} />);
+            expect(screen.queryByRole('button', { name: /listen/i })).not.toBeInTheDocument();
+        });
+
+        test('shown and speaks the phrase when enabled with an installed voice', () => {
+            renderWithTheme(
+                <TableRowActions row={phraseRow} onEdit={() => {}} onDelete={() => {}} ttsEnabled targetLang="pl" />
+            );
+            const play = screen.getByRole('button', { name: /listen/i });
+            fireEvent.click(play);
+            expect(speak).toHaveBeenCalledWith('kot', 'pl_PL-gosia-medium');
+        });
+
+        test('hidden when no voice for the language is installed', () => {
+            installedVoiceForLang.mockReturnValue(null);
+            renderWithTheme(
+                <TableRowActions row={phraseRow} onEdit={() => {}} onDelete={() => {}} ttsEnabled targetLang="pl" />
+            );
+            expect(screen.queryByRole('button', { name: /listen/i })).not.toBeInTheDocument();
+        });
     });
 });


### PR DESCRIPTION
## What & why

The admin **Browse Records** table now lets you hear phrases spoken with the in-browser TTS.

- **Per-row Play button** in the Actions column (`ListenButton`) — speaks the phrase using the language set's voice. Self-gates: appears only when TTS is enabled globally and a voice for the set's target language is installed.
- **"Voice packs" button** above the table — opens the existing `VoiceManager` dialog to download/manage voices for the selected set's target language. After a download, the row buttons light up (a refresh key re-renders the table).

Reuses the proven `ListenButton` / `VoiceManager` / `useLocalTts` from the Review sprint and the global TTS enable setting (`useSystemPreferences`). No backend or i18n changes (`target_lang` already comes from the admin language-sets API; `review.voices`/`review.listen` keys already exist).

## Testing
- **Real browser (Firefox)**: admin → Browse Records shows the Voice packs button; the dialog lists the real pl voices with download actions; rows load with the actions column. Per-row Play button correctly stays hidden until a voice is actually downloaded.
- **4 new unit tests** (play button gating on `ttsEnabled` + installed voice + speaks on click; Voice packs button gated on `target_lang`).
- Full suite **451 pass**, lint clean, production build OK.