### PR TITLE
fix: use dynamic free ports in the e2e runner

### DIFF
--- a/helpers/e2e/README.md
+++ b/helpers/e2e/README.md
@@ -27,8 +27,10 @@ cd frontend && npm ci        # installs @playwright/test
 helpers/e2e/run-e2e.sh       # builds, serves, seeds, runs all 4 test executions
 ```
 
-Useful env overrides: `E2E_APP_PORT` (default 8099), `E2E_PG_PORT` (default 55432),
-`E2E_KEEP_UP=1` (leave the stack running for debugging).
+Ports default to free/random (the app port is probed, Postgres gets one from docker) so
+parallel jobs and leftover containers on a shared agent don't clash. Useful env overrides:
+`E2E_APP_PORT`, `E2E_PG_PORT` (pin them), `E2E_KEEP_UP=1` (leave the stack running for
+debugging).
 
 ## CI
 

--- a/helpers/e2e/run-e2e.sh
+++ b/helpers/e2e/run-e2e.sh
@@ -14,14 +14,15 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-APP_PORT="${E2E_APP_PORT:-8099}"
-PG_PORT="${E2E_PG_PORT:-55432}"
+# Ports default to free/random (resolved after preflight) so parallel jobs or leftover
+# containers on a shared agent don't clash; override with E2E_APP_PORT / E2E_PG_PORT.
+APP_PORT="${E2E_APP_PORT:-}"
+PG_PORT="${E2E_PG_PORT:-}"
 PG_IMAGE="${E2E_PG_IMAGE:-postgres:18-alpine}"
 PG_NAME="osm-e2e-pg-$$"
 VENV="$ROOT/backend/.venv"
 ADMIN_USER="e2e-admin"
 ADMIN_PASS="e2e-pass-$$"
-BASE_URL="http://127.0.0.1:${APP_PORT}"
 
 BACKEND_PID=""
 cleanup() {
@@ -32,8 +33,13 @@ cleanup() {
 [ -n "${E2E_KEEP_UP:-}" ] || trap cleanup EXIT
 
 echo "==> Preflight"
-command -v docker >/dev/null || { echo "docker is required"; exit 1; }
-command -v node   >/dev/null || { echo "node is required"; exit 1; }
+command -v docker  >/dev/null || { echo "docker is required"; exit 1; }
+command -v node    >/dev/null || { echo "node is required"; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is required"; exit 1; }
+
+# Resolve a free host port for the app unless pinned (Postgres gets one from docker below).
+[ -n "$APP_PORT" ] || APP_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+BASE_URL="http://127.0.0.1:${APP_PORT}"
 
 # Self-provision the backend venv when missing (the CI E2E stage runs on its own agent with
 # a fresh workspace, so it can't rely on an earlier Install Dependencies stage).
@@ -45,10 +51,18 @@ if [ ! -x "$VENV/bin/python" ]; then
   ( cd "$ROOT" && "$VENV/bin/pip" install --quiet ".[dev]" )
 fi
 
-echo "==> Starting Postgres ($PG_IMAGE) on :$PG_PORT"
+echo "==> Starting Postgres ($PG_IMAGE)"
 docker rm -f "$PG_NAME" >/dev/null 2>&1 || true
-docker run -d --name "$PG_NAME" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=osmosmjerka \
-  -p "${PG_PORT}:5432" "$PG_IMAGE" >/dev/null
+if [ -n "$PG_PORT" ]; then
+  docker run -d --name "$PG_NAME" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=osmosmjerka \
+    -p "127.0.0.1:${PG_PORT}:5432" "$PG_IMAGE" >/dev/null
+else
+  # Let docker assign a free host port, then read it back — no fixed port to clash on.
+  docker run -d --name "$PG_NAME" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=osmosmjerka \
+    -p "127.0.0.1:0:5432" "$PG_IMAGE" >/dev/null
+  PG_PORT="$(docker port "$PG_NAME" 5432/tcp | head -1 | sed 's/.*://')"
+fi
+echo "    Postgres on :$PG_PORT, app will use :$APP_PORT"
 for _ in $(seq 1 60); do docker exec "$PG_NAME" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
 
 echo "==> Building frontend and serving it from the backend"


### PR DESCRIPTION
## Problem

The E2E stage failed on the CD agent with:

```
docker: Error response from daemon: failed to bind host port 0.0.0.0:55432/tcp: address already in use
```

`helpers/e2e/run-e2e.sh` bound **fixed host ports** (app 8099, Postgres 55432). On the shared main agent a leftover container (from a hard-killed run) or a concurrent job can already hold that port, so the run dies before it starts.

## Fix

Default both ports to free/random, still overridable via `E2E_APP_PORT` / `E2E_PG_PORT`:
- **Postgres**: publish with `-p 127.0.0.1:0:5432` so docker picks a free host port, then read it back with `docker port`.
- **App**: probe a free port via a short `python3` socket bind.

Also binds Postgres to 127.0.0.1 explicitly.

## Testing
Ran the full suite locally with the change — **Postgres on :32768, app on :33865** (both auto-assigned), **4/4 tests pass**, `E2E passed`, no leftover containers.