### PR TITLE
fix: make admin play button match edit/delete buttons

### DIFF
--- a/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { Box, Button } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import { useTranslation } from 'react-i18next';
-import ListenButton from '../../../game/components/Review/ListenButton';
+import { installedVoiceForLang, speak } from '../../../../hooks/localTts';
 
 export default function TableRowActions({
     row,
@@ -14,12 +15,22 @@ export default function TableRowActions({
 }) {
     const { t } = useTranslation();
 
+    // Speak the phrase with the language set's in-browser voice. Shown only when a voice
+    // for the target language is installed (kept in the cheap localStorage mirror).
+    const voiceId = ttsEnabled && targetLang ? installedVoiceForLang(targetLang) : null;
+
     return (
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', justifyContent: 'center' }}>
-            {/* Speak the phrase with the language set's in-browser voice. Renders only when a
-                voice for the target language is installed (ListenButton self-gates). */}
-            {ttsEnabled && targetLang && (
-                <ListenButton text={row.phrase} lang={targetLang} t={t} size="medium" />
+            {voiceId && (
+                <Button
+                    size="small"
+                    onClick={() => speak(row.phrase, voiceId)}
+                    aria-label={t('review.listen', 'Listen')}
+                    title={t('review.listen', 'Listen')}
+                    sx={{ minWidth: 0, width: 36, height: 36, fontSize: '1.1rem', lineHeight: 1 }}
+                >
+                    <VolumeUpIcon fontSize="small" />
+                </Button>
             )}
             <Button
                 size="small"


### PR DESCRIPTION
Follow-up to the TTS play button in admin browse records: render the play action as a `Button` with the same 36×36 styling as the Edit and Delete actions (it was a round `IconButton`), so the Actions column is visually consistent.

Gating/behavior unchanged — still shows only when TTS is enabled and a voice for the set's target language is installed, and speaks the phrase on click. Existing TableRowActions tests cover it (button renders + speaks).