### PR TITLE
fix: self-host in-browser TTS runtime (fixes playback)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
         "@babel/core": "^7.28.4",
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
+        "@diffusionstudio/piper-wasm": "^1.0.0",
         "@eslint/js": "^9.36.0",
         "@playwright/test": "^1.49.0",
         "@testing-library/jest-dom": "^6.8.0",

--- a/frontend/src/hooks/localTts.js
+++ b/frontend/src/hooks/localTts.js
@@ -1,4 +1,5 @@
 import logger from "@shared/utils/logger";
+import { getAssetUrl } from "@shared/utils/assets";
 
 /**
  * Wrapper around @mintplex-labs/piper-tts-web — Piper VITS neural voices running fully
@@ -18,6 +19,15 @@ function getEngine() {
   if (!enginePromise) enginePromise = import("@mintplex-labs/piper-tts-web");
   return enginePromise;
 }
+
+// Self-hosted runtime paths (see the tts-wasm-assets plugin in vite.config.mjs). Without
+// these, piper-tts-web defaults to CDN URLs that fail on CSP/CORS and a stale onnx path.
+// getAssetUrl resolves against the app base ("/static/" in prod, "/" in dev/test).
+const WASM_PATHS = {
+  onnxWasm: getAssetUrl("wasm/"),
+  piperData: getAssetUrl("wasm/piper_phonemize.data"),
+  piperWasm: getAssetUrl("wasm/piper_phonemize.wasm"),
+};
 
 export function isLocalTtsSupported() {
   return (
@@ -103,7 +113,12 @@ export async function speak(text, voiceId) {
   if (!text || !voiceId) return;
   try {
     const tts = await getEngine();
-    const wav = await tts.predict({ text, voiceId });
+    // Use TtsSession directly (not the module-level predict) so we can inject the
+    // self-hosted wasmPaths. TtsSession is a singleton — first creation sets the paths;
+    // set voiceId each call so voice switches still work.
+    const session = await tts.TtsSession.create({ voiceId, wasmPaths: WASM_PATHS });
+    session.voiceId = voiceId;
+    const wav = await session.predict(text);
     const url = URL.createObjectURL(wav);
     if (currentAudio) currentAudio.pause();
     currentAudio = new window.Audio(url);

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -6,9 +6,48 @@ import path from 'path';
 // Read version from package.json for fallback when env var is not set
 const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
+// Self-host the in-browser TTS runtime files so nothing is fetched from a CDN (the Piper
+// library otherwise pulls the onnxruntime loader + phonemizer from cdnjs/jsdelivr, which
+// fail on CSP/CORS and a stale path). We only need the small onnx JS loader (.mjs) — the
+// heavy .wasm is already emitted by Vite from onnxruntime's `new URL(...)` — plus the piper
+// phonemizer data/wasm. Served under <base>/wasm/ in both dev and build. See hooks/localTts.js.
+function ttsWasmAssets() {
+    const files = [
+        ['ort-wasm-simd-threaded.jsep.mjs', 'onnxruntime-web/dist/ort-wasm-simd-threaded.jsep.mjs'],
+        ['ort-wasm-simd-threaded.jsep.wasm', 'onnxruntime-web/dist/ort-wasm-simd-threaded.jsep.wasm'],
+        ['piper_phonemize.data', '@diffusionstudio/piper-wasm/build/piper_phonemize.data'],
+        ['piper_phonemize.wasm', '@diffusionstudio/piper-wasm/build/piper_phonemize.wasm'],
+    ];
+    const abs = (rel) => path.resolve(__dirname, 'node_modules', rel);
+    const mime = (n) =>
+        n.endsWith('.mjs') ? 'text/javascript' : n.endsWith('.wasm') ? 'application/wasm' : 'application/octet-stream';
+    return {
+        name: 'tts-wasm-assets',
+        generateBundle(_options, bundle) {
+            // onnxruntime loads its wasm from our wasmPaths dir, so Vite's auto-emitted
+            // hashed copy (from onnxruntime's `new URL(...)`) is dead weight — drop it.
+            for (const key of Object.keys(bundle)) {
+                if (/ort-wasm-simd-threaded\.jsep.*\.wasm$/.test(key)) delete bundle[key];
+            }
+            for (const [name, rel] of files) {
+                this.emitFile({ type: 'asset', fileName: `wasm/${name}`, source: readFileSync(abs(rel)) });
+            }
+        },
+        configureServer(server) {
+            server.middlewares.use((req, res, next) => {
+                const url = (req.url || '').split('?')[0];
+                const hit = files.find(([name]) => url.endsWith(`/wasm/${name}`));
+                if (!hit) return next();
+                res.setHeader('Content-Type', mime(hit[0]));
+                res.end(readFileSync(abs(hit[1])));
+            });
+        },
+    };
+}
+
 export default defineConfig({
     root: './',
-    plugins: [react()],
+    plugins: [react(), ttsWasmAssets()],
     css: {
         devSourcemap: true, // CSS source maps
     },


### PR DESCRIPTION
## Problem

TTS never actually synthesized in production — clicking play failed with `Error: no available backend found`. `@mintplex-labs/piper-tts-web` defaults its onnxruntime loader and Piper phonemizer to CDNs:
- `cdnjs.cloudflare.com/.../onnxruntime-web/1.18.0/ort-wasm-simd-threaded.jsep.mjs` — **404s** (cdnjs doesn't host that file → `text/html` MIME error), and
- `cdn.jsdelivr.net/.../piper_phonemize.*`

so the WASM runtime never initialized. This affected **all** TTS (the Review sprint too), not just the new admin button.

## Fix — serve the runtime from the app's own origin

- A small Vite plugin (`tts-wasm-assets`) emits the onnx loader (`ort-wasm-simd-threaded.jsep.mjs` + `.wasm`) and the Piper phonemizer (`piper_phonemize.data` + `.wasm`) under `<base>/wasm/`, and serves them in dev. It also drops Vite's auto-emitted hashed onnx `.wasm` (dead once we serve our own), so the bundle doesn't grow.
- `localTts.js` passes those local paths as `wasmPaths` to `TtsSession` (via `getAssetUrl`, jest/prod-safe), instead of the module `predict` that can't override paths.
- Adds `@diffusionstudio/piper-wasm` as a devDependency (source of the phonemizer files, copied at build).

Backend already serves `.mjs` as `text/javascript` and `.wasm` as `application/wasm` (verified).

## Testing
Verified end-to-end in a real browser (Firefox) against the built app: downloaded a voice, clicked play → **audio synthesized and played**, **0 requests to any CDN**, all four runtime files loaded from `/wasm/` (200), and **0 TTS errors**. Full suite 451 pass; lint clean.