### PR TITLE
fix: always npm install in e2e runner (stale workspace)

### DIFF
--- a/helpers/e2e/run-e2e.sh
+++ b/helpers/e2e/run-e2e.sh
@@ -66,8 +66,11 @@ echo "    Postgres on :$PG_PORT, app will use :$APP_PORT"
 for _ in $(seq 1 60); do docker exec "$PG_NAME" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
 
 echo "==> Building frontend and serving it from the backend"
-# npm install (not ci): package-lock.json is git-ignored in this repo.
-( cd "$ROOT/frontend" && [ -d node_modules ] || npm install )
+# Always install (not conditional on node_modules existing): the E2E agent reuses its
+# workspace between builds, so a cached node_modules can be stale and miss deps added since
+# (e.g. the TTS build assets). npm install is a fast no-op when already up to date.
+# Not `npm ci` — package-lock.json is git-ignored in this repo.
+( cd "$ROOT/frontend" && npm install )
 ( cd "$ROOT/frontend" && VITE_BASE_PATH=/static/ npm run build )
 rm -rf "$ROOT/backend/static"
 cp -r "$ROOT/frontend/build" "$ROOT/backend/static"


### PR DESCRIPTION
## Problem

The E2E stage failed on main after the TTS-WASM change merged:

```
[plugin tts-wasm-assets] Error: ENOENT: no such file or directory, open
'.../node_modules/@diffusionstudio/piper-wasm/build/piper_phonemize.data'
```

The package **is** in the tarball — but `run-e2e.sh` guarded the install with
`[ -d node_modules ] || npm install`. The E2E agent reuses its workspace between builds, so a
cached `node_modules` from before `@diffusionstudio/piper-wasm` was added made the runner **skip
the install** (vite was present from the old install, the new build-asset dep wasn't) → the
build plugin couldn't find the phonemizer file.

## Fix

Always run `npm install` in the runner. It's a fast no-op when up to date and picks up any deps
added since the workspace was last populated. (Not `npm ci` — package-lock.json is git-ignored here.)

## Testing

Reproduced by deleting `node_modules/@diffusionstudio/piper-wasm` (simulating the stale
workspace) then running `helpers/e2e/run-e2e.sh`: the runner reinstalled it, the build
succeeded, and all **4/4** specs passed (`E2E passed`).