### PR TITLE
feat: warm up TTS engine on play-button hover

### DIFF
--- a/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/TableRowActions.jsx
@@ -4,7 +4,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import { useTranslation } from 'react-i18next';
-import { installedVoiceForLang, speak } from '../../../../hooks/localTts';
+import { installedVoiceForLang, speak, warmup } from '../../../../hooks/localTts';
 
 export default function TableRowActions({
     row,
@@ -25,6 +25,8 @@ export default function TableRowActions({
                 <Button
                     size="small"
                     onClick={() => speak(row.phrase, voiceId)}
+                    onPointerEnter={() => warmup(voiceId)}
+                    onFocus={() => warmup(voiceId)}
                     aria-label={t('review.listen', 'Listen')}
                     title={t('review.listen', 'Listen')}
                     sx={{ minWidth: 0, width: 36, height: 36, fontSize: '1.1rem', lineHeight: 1 }}

--- a/frontend/src/features/admin/components/BrowseRecords/__tests__/TableRowActions.test.jsx
+++ b/frontend/src/features/admin/components/BrowseRecords/__tests__/TableRowActions.test.jsx
@@ -3,12 +3,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import TableRowActions from '../TableRowActions';
 import { withI18n } from '../../../../../testUtils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { installedVoiceForLang, speak } from '../../../../../hooks/localTts';
+import { installedVoiceForLang, speak, warmup } from '../../../../../hooks/localTts';
 
-// ListenButton (used for the play action) reads installed voices + speaks through localTts.
+// The play action reads installed voices + speaks/warms through localTts.
 jest.mock('../../../../../hooks/localTts', () => ({
     installedVoiceForLang: jest.fn(() => 'pl_PL-gosia-medium'),
     speak: jest.fn(),
+    warmup: jest.fn(),
 }));
 
 // Create a test theme
@@ -90,6 +91,15 @@ describe('TableRowActions', () => {
             const play = screen.getByRole('button', { name: /listen/i });
             fireEvent.click(play);
             expect(speak).toHaveBeenCalledWith('kot', 'pl_PL-gosia-medium');
+        });
+
+        test('warms up the engine on hover', () => {
+            warmup.mockClear();
+            renderWithTheme(
+                <TableRowActions row={phraseRow} onEdit={() => {}} onDelete={() => {}} ttsEnabled targetLang="pl" />
+            );
+            fireEvent.pointerEnter(screen.getByRole('button', { name: /listen/i }));
+            expect(warmup).toHaveBeenCalledWith('pl_PL-gosia-medium');
         });
 
         test('hidden when no voice for the language is installed', () => {

--- a/frontend/src/features/game/components/Review/ListenButton.jsx
+++ b/frontend/src/features/game/components/Review/ListenButton.jsx
@@ -1,6 +1,6 @@
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import { IconButton, Tooltip } from "@mui/material";
-import { installedVoiceForLang, speak } from "../../../../hooks/localTts";
+import { installedVoiceForLang, speak, warmup } from "../../../../hooks/localTts";
 
 /**
  * Speaker button using an in-browser Piper voice. Shows only when a voice for `lang`
@@ -13,7 +13,13 @@ export default function ListenButton({ text, lang, t, size = "small" }) {
   const label = t("review.listen", "Listen");
   return (
     <Tooltip title={label} arrow>
-      <IconButton size={size} onClick={() => speak(text, voiceId)} aria-label={label}>
+      <IconButton
+        size={size}
+        onClick={() => speak(text, voiceId)}
+        onPointerEnter={() => warmup(voiceId)}
+        onFocus={() => warmup(voiceId)}
+        aria-label={label}
+      >
         <VolumeUpIcon fontSize="inherit" />
       </IconButton>
     </Tooltip>

--- a/frontend/src/hooks/localTts.js
+++ b/frontend/src/hooks/localTts.js
@@ -29,6 +29,24 @@ const WASM_PATHS = {
   piperWasm: getAssetUrl("wasm/piper_phonemize.wasm"),
 };
 
+// Preload the engine + WASM runtime ahead of the first speak (e.g. on hover/focus of a
+// play button) so the first click isn't stuck loading ~45MB of onnx/piper WASM. Idempotent:
+// the heavy work runs once and the TtsSession singleton it creates is reused by speak().
+let warmupPromise = null;
+export function warmup(voiceId) {
+  if (warmupPromise) return warmupPromise;
+  warmupPromise = (async () => {
+    try {
+      const tts = await getEngine();
+      if (voiceId) await tts.TtsSession.create({ voiceId, wasmPaths: WASM_PATHS });
+    } catch (error) {
+      warmupPromise = null; // allow a later attempt to retry
+      logger.warn("TTS warmup failed:", error);
+    }
+  })();
+  return warmupPromise;
+}
+
 export function isLocalTtsSupported() {
   return (
     typeof window !== "undefined" &&


### PR DESCRIPTION
Reduces the first-play lag reported for in-browser TTS. On hover/focus of a play button (admin Browse Records **and** the Review sprint's ListenButton), preload the onnx + piper WASM runtime so the first click isn't stuck loading ~45MB of WASM. Idempotent (`warmup()` runs the heavy work once and the TtsSession singleton is reused by `speak()`).

Note: this hides the *engine-init* portion of the first-click delay; per-synthesis inference stays single-threaded (making it multi-threaded would need app-wide cross-origin isolation / COOP+COEP, which we opted not to do). The `numThreads` console warning is a harmless onnxruntime fallback, and the `installHook.js.map` source-map error is the React DevTools browser extension — neither is our code.

## Testing
- Unit: new test asserts `warmup(voiceId)` fires on hover; full suite **452 pass**, lint clean, build OK.
- Real browser (Firefox): after downloading a voice, **hovering** the play button (no click) triggers the engine WASM load (`ort-wasm-*.mjs`/`.wasm` requested) — 0 → 2 requests — so the engine is warm before the click.