### PR TITLE
feat: Keep & edit for duplicates + export all phrases (incl. ignored)

### DIFF
--- a/backend/osmosmjerka/admin_api/phrases.py
+++ b/backend/osmosmjerka/admin_api/phrases.py
@@ -600,7 +600,9 @@ async def export_data(
 ) -> StreamingResponse:
     """Export phrases as CSV from specified language set"""
     try:
-        rows = await db_manager.get_phrases(language_set_id, category)
+        # Export every phrase (including ignored categories), matching what the admin browse
+        # table shows — get_phrases() would strip the set's default-ignored categories.
+        rows = await db_manager.get_phrases_for_admin(language_set_id, category)
         output = io.StringIO()
 
         # Use CSV writer to properly handle semicolon delimiter and escape special characters

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -309,9 +309,10 @@ def test_upload_text_with_tab_separator_auto_detect(
 
 
 # Test export functionality
-@patch("osmosmjerka.database.db_manager.get_phrases")
+@patch("osmosmjerka.database.db_manager.get_phrases_for_admin")
 def test_export_data(mock_get_phrases, client, mock_admin_user):
-    """Test exporting data as CSV"""
+    """Test exporting data as CSV — uses the admin (unfiltered) fetch so ignored categories
+    are still exported."""
     # Override the dependency
     app.dependency_overrides[require_admin_access] = lambda: mock_admin_user
     mock_get_phrases.return_value = [
@@ -332,7 +333,7 @@ def test_export_data(mock_get_phrases, client, mock_admin_user):
     mock_get_phrases.assert_called_once_with(None, "Spanish")
 
 
-@patch("osmosmjerka.database.db_manager.get_phrases")
+@patch("osmosmjerka.database.db_manager.get_phrases_for_admin")
 def test_export_data_all_categories(mock_get_phrases, client, mock_admin_user):
     """Test exporting all categories"""
     # Override the dependency

--- a/frontend/src/features/admin/components/AdminPanel/DuplicateManagement.jsx
+++ b/frontend/src/features/admin/components/AdminPanel/DuplicateManagement.jsx
@@ -40,6 +40,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { LanguageSetSelector } from '../../../../shared';
 import { API_ENDPOINTS } from '../../../../shared/constants/constants';
+import KeepAndEditDialog from './KeepAndEditDialog';
 
 export default function DuplicateManagement({ currentUser, selectedLanguageSetId }) {
     const { t } = useTranslation();
@@ -55,6 +56,9 @@ export default function DuplicateManagement({ currentUser, selectedLanguageSetId
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [phrasesToDelete, setPhrasesToDelete] = useState([]);
     const [deleting, setDeleting] = useState(false);
+    // Keep & edit: resolve a group by keeping one (edited) phrase and deleting the rest.
+    const [keepEditState, setKeepEditState] = useState({ open: false, keepPhrase: null, otherPhrases: [] });
+    const [keepEditSaving, setKeepEditSaving] = useState(false);
 
     // Pagination state
     const [currentPage, setCurrentPage] = useState(1);
@@ -147,6 +151,52 @@ export default function DuplicateManagement({ currentUser, selectedLanguageSetId
         setPhrasesToDelete(toDelete);
         setDeleteDialogOpen(true);
     }, []);
+
+    const handleKeepAndEdit = useCallback((phrases, keepPhraseId) => {
+        setKeepEditState({
+            open: true,
+            keepPhrase: phrases.find(p => p.id === keepPhraseId) || null,
+            otherPhrases: phrases.filter(p => p.id !== keepPhraseId),
+        });
+    }, []);
+
+    const confirmKeepAndEdit = useCallback(async (fields) => {
+        const { keepPhrase, otherPhrases } = keepEditState;
+        if (!keepPhrase) return;
+        setKeepEditSaving(true);
+        try {
+            const token = localStorage.getItem('adminToken');
+            const auth = { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+            // 1) update the kept phrase with the edited fields
+            const updateRes = await fetch(
+                `/admin/row/${keepPhrase.id}?language_set_id=${activeLanguageSetId}`,
+                { method: 'PUT', headers: auth, body: JSON.stringify(fields) }
+            );
+            if (!updateRes.ok) throw new Error(`HTTP ${updateRes.status}: ${updateRes.statusText}`);
+
+            // 2) delete the other duplicates
+            const otherIds = otherPhrases.map(p => p.id);
+            if (otherIds.length) {
+                const deleteRes = await fetch(
+                    `${API_ENDPOINTS.ADMIN_DUPLICATES}?language_set_id=${activeLanguageSetId}`,
+                    { method: 'DELETE', headers: auth, body: JSON.stringify(otherIds) }
+                );
+                if (!deleteRes.ok) throw new Error(`HTTP ${deleteRes.status}: ${deleteRes.statusText}`);
+            }
+
+            setOperationResult({ type: 'keepEdit', data: { phrase: fields.phrase, deleted_count: otherIds.length } });
+            setError('');
+            setKeepEditState({ open: false, keepPhrase: null, otherPhrases: [] });
+            setSelectedPhrases(new Set());
+            await loadDuplicates();
+        } catch (err) {
+            logger.error('Error in keep & edit:', err);
+            setError(t('keep_edit_failed', 'Failed to keep & edit: {{error}}', { error: err.message }));
+        } finally {
+            setKeepEditSaving(false);
+        }
+    }, [keepEditState, activeLanguageSetId, loadDuplicates, t]);
 
     const handleMergeCategories = useCallback(async (phrases, keepPhraseId) => {
         const duplicateIds = phrases.filter(p => p.id !== keepPhraseId).map(p => p.id);
@@ -398,6 +448,13 @@ export default function DuplicateManagement({ currentUser, selectedLanguageSetId
                                 </Box>
                             )}
                         </Box>
+                    ) : operationResult.type === 'keepEdit' ? (
+                        <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                            {t('keep_edit_success', 'Kept "{{phrase}}" and deleted {{count}} duplicate(s).', {
+                                phrase: operationResult.data.phrase,
+                                count: operationResult.data.deleted_count,
+                            })}
+                        </Typography>
                     ) : null}
                 </Alert>
             )}
@@ -530,6 +587,15 @@ export default function DuplicateManagement({ currentUser, selectedLanguageSetId
                                                                         {t('merge_categories', 'Merge Categories')}
                                                                     </Button>
                                                                 </Tooltip>
+                                                                <Tooltip title={t('keep_and_edit_tooltip', 'Edit this phrase (combine translations), then delete the others')}>
+                                                                    <Button
+                                                                        size="small"
+                                                                        variant="outlined"
+                                                                        onClick={() => handleKeepAndEdit(group.duplicates, phrase.id)}
+                                                                    >
+                                                                        {t('keep_and_edit', 'Keep & edit')}
+                                                                    </Button>
+                                                                </Tooltip>
                                                             </Box>
                                                         </TableCell>
                                                     </TableRow>
@@ -590,6 +656,15 @@ export default function DuplicateManagement({ currentUser, selectedLanguageSetId
                     </Button>
                 </DialogActions>
             </Dialog>
+
+            <KeepAndEditDialog
+                open={keepEditState.open}
+                keepPhrase={keepEditState.keepPhrase}
+                otherPhrases={keepEditState.otherPhrases}
+                onClose={() => setKeepEditState({ open: false, keepPhrase: null, otherPhrases: [] })}
+                onSave={confirmKeepAndEdit}
+                saving={keepEditSaving}
+            />
         </Paper>
     );
 }

--- a/frontend/src/features/admin/components/AdminPanel/KeepAndEditDialog.jsx
+++ b/frontend/src/features/admin/components/AdminPanel/KeepAndEditDialog.jsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    TextField,
+    Button,
+    Box,
+    Typography,
+    Stack,
+    Divider,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Resolve a duplicate group by keeping ONE phrase (with edits) and deleting the rest.
+ * Pre-fills the kept phrase's fields and surfaces the other duplicates' translations/categories
+ * so the admin can combine them (e.g. two synonym translations) before saving.
+ */
+export default function KeepAndEditDialog({ open, onClose, keepPhrase, otherPhrases = [], onSave, saving = false }) {
+    const { t } = useTranslation();
+    const [phrase, setPhrase] = useState('');
+    const [translation, setTranslation] = useState('');
+    const [categories, setCategories] = useState('');
+
+    useEffect(() => {
+        if (open && keepPhrase) {
+            setPhrase(keepPhrase.phrase || '');
+            setTranslation(keepPhrase.translation || '');
+            setCategories(keepPhrase.categories || '');
+        }
+    }, [open, keepPhrase]);
+
+    // Append a translation, joined with "; ", skipping empties/exact duplicates already present.
+    const appendTranslation = (text) => {
+        const add = (text || '').trim();
+        if (!add) return;
+        setTranslation((cur) => {
+            const parts = cur.split(/\s*;\s*|\n/).map((s) => s.trim()).filter(Boolean);
+            if (parts.includes(add)) return cur;
+            return parts.length ? `${parts.join('; ')}; ${add}` : add;
+        });
+    };
+
+    const appendAll = () => otherPhrases.forEach((p) => appendTranslation(p.translation));
+
+    const canSave = phrase.trim() && translation.trim() && !saving;
+
+    return (
+        <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>{t('keep_edit_title', 'Keep & edit this phrase')}</DialogTitle>
+            <DialogContent dividers>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <TextField
+                        label={t('phrase', 'Phrase')}
+                        value={phrase}
+                        onChange={(e) => setPhrase(e.target.value)}
+                        fullWidth
+                        size="small"
+                    />
+                    <TextField
+                        label={t('translation', 'Translation')}
+                        value={translation}
+                        onChange={(e) => setTranslation(e.target.value)}
+                        fullWidth
+                        size="small"
+                        multiline
+                        minRows={2}
+                    />
+                    <TextField
+                        label={t('categories', 'Categories')}
+                        value={categories}
+                        onChange={(e) => setCategories(e.target.value)}
+                        fullWidth
+                        size="small"
+                        helperText={t('categories_space_separated', 'Space-separated')}
+                    />
+
+                    {otherPhrases.length > 0 && (
+                        <>
+                            <Divider />
+                            <Box>
+                                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+                                    <Typography variant="subtitle2">
+                                        {t('other_duplicates_deleted', 'Other duplicates (will be deleted)')}
+                                    </Typography>
+                                    <Button size="small" onClick={appendAll}>
+                                        {t('append_all_translations', 'Append all translations')}
+                                    </Button>
+                                </Box>
+                                <Stack spacing={0.5}>
+                                    {otherPhrases.map((p) => (
+                                        <Box
+                                            key={p.id}
+                                            sx={{ display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'space-between' }}
+                                        >
+                                            <Typography variant="body2" sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                                                {p.translation}
+                                                {p.categories ? (
+                                                    <Typography component="span" variant="caption" color="text.secondary">
+                                                        {' '}({p.categories})
+                                                    </Typography>
+                                                ) : null}
+                                            </Typography>
+                                            <Button size="small" onClick={() => appendTranslation(p.translation)} sx={{ flexShrink: 0 }}>
+                                                {t('append_translation', '+ translation')}
+                                            </Button>
+                                        </Box>
+                                    ))}
+                                </Stack>
+                            </Box>
+                        </>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={saving}>
+                    {t('cancel', 'Cancel')}
+                </Button>
+                <Button
+                    variant="contained"
+                    onClick={() => onSave({ phrase: phrase.trim(), translation: translation.trim(), categories: categories.trim() })}
+                    disabled={!canSave}
+                >
+                    {t('save_and_keep', 'Save & keep this')}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/frontend/src/features/admin/components/AdminPanel/__tests__/KeepAndEditDialog.test.jsx
+++ b/frontend/src/features/admin/components/AdminPanel/__tests__/KeepAndEditDialog.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import KeepAndEditDialog from '../KeepAndEditDialog';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key, fallback) => fallback || key }),
+}));
+
+const theme = createTheme();
+const renderDialog = (props = {}) =>
+    render(
+        <ThemeProvider theme={theme}>
+            <KeepAndEditDialog
+                open
+                keepPhrase={{ id: 1, phrase: 'privit', translation: 'hi', categories: 'greetings' }}
+                otherPhrases={[
+                    { id: 2, phrase: 'privit', translation: 'hallo', categories: 'basics' },
+                    { id: 3, phrase: 'privit', translation: 'hi', categories: 'x' },
+                ]}
+                onClose={() => {}}
+                onSave={jest.fn()}
+                {...props}
+            />
+        </ThemeProvider>
+    );
+
+describe('KeepAndEditDialog', () => {
+    test('pre-fills the kept phrase fields', () => {
+        renderDialog();
+        expect(screen.getByLabelText('Phrase')).toHaveValue('privit');
+        expect(screen.getByLabelText('Translation')).toHaveValue('hi');
+        expect(screen.getByLabelText('Categories')).toHaveValue('greetings');
+    });
+
+    test('lists other duplicates that will be deleted', () => {
+        renderDialog();
+        expect(screen.getByText(/Other duplicates/i)).toBeInTheDocument();
+        expect(screen.getByText(/hallo/)).toBeInTheDocument();
+    });
+
+    test('"append all" combines the other translations, skipping duplicates', () => {
+        renderDialog();
+        fireEvent.click(screen.getByText('Append all translations'));
+        // starts "hi"; appends "hallo" (new) and "hi" (already present -> skipped)
+        expect(screen.getByLabelText('Translation')).toHaveValue('hi; hallo');
+    });
+
+    test('save reports the edited fields', () => {
+        const onSave = jest.fn();
+        renderDialog({ onSave });
+        fireEvent.change(screen.getByLabelText('Translation'), { target: { value: 'hi; hallo' } });
+        fireEvent.click(screen.getByRole('button', { name: /Save & keep this/i }));
+        expect(onSave).toHaveBeenCalledWith({ phrase: 'privit', translation: 'hi; hallo', categories: 'greetings' });
+    });
+
+    test('save is disabled without a phrase or translation', () => {
+        renderDialog({ keepPhrase: { id: 1, phrase: '', translation: '', categories: '' }, otherPhrases: [] });
+        expect(screen.getByRole('button', { name: /Save & keep this/i })).toBeDisabled();
+    });
+});

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -913,5 +913,15 @@
     "hint_reveal": "Reveal phrase",
     "give_up": "Give up",
     "forfeited": "Answers revealed. Better luck next time!"
-  }
+  },
+  "keep_and_edit": "Keep & edit",
+  "keep_and_edit_tooltip": "Edit this phrase (combine translations), then delete the others",
+  "keep_edit_title": "Keep & edit this phrase",
+  "keep_edit_success": "Kept \"{{phrase}}\" and deleted {{count}} duplicate(s).",
+  "keep_edit_failed": "Failed to keep & edit: {{error}}",
+  "other_duplicates_deleted": "Other duplicates (will be deleted)",
+  "append_translation": "+ translation",
+  "append_all_translations": "Append all translations",
+  "save_and_keep": "Save & keep this",
+  "categories_space_separated": "Space-separated"
 }

--- a/frontend/src/locales/hr.json
+++ b/frontend/src/locales/hr.json
@@ -914,5 +914,15 @@
     "hint_reveal": "Otkrij frazu",
     "give_up": "Predaj se",
     "forfeited": "Odgovori otkriveni. Više sreće drugi put!"
-  }
+  },
+  "keep_and_edit": "Zadrži i uredi",
+  "keep_and_edit_tooltip": "Uredi ovu frazu (spoji prijevode), zatim izbriši ostale",
+  "keep_edit_title": "Zadrži i uredi ovu frazu",
+  "keep_edit_success": "Zadržano „{{phrase}}” i izbrisano {{count}} duplikat(a).",
+  "keep_edit_failed": "Nije uspjelo zadržavanje i uređivanje: {{error}}",
+  "other_duplicates_deleted": "Ostali duplikati (bit će izbrisani)",
+  "append_translation": "+ prijevod",
+  "append_all_translations": "Dodaj sve prijevode",
+  "save_and_keep": "Spremi i zadrži",
+  "categories_space_separated": "Odvojeno razmakom"
 }

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -919,5 +919,15 @@
     "hint_reveal": "Odkryj frazę",
     "give_up": "Poddaj się",
     "forfeited": "Odpowiedzi odsłonięte. Powodzenia następnym razem!"
-  }
+  },
+  "keep_and_edit": "Zachowaj i edytuj",
+  "keep_and_edit_tooltip": "Edytuj tę frazę (połącz tłumaczenia), a następnie usuń pozostałe",
+  "keep_edit_title": "Zachowaj i edytuj tę frazę",
+  "keep_edit_success": "Zachowano „{{phrase}}” i usunięto {{count}} duplikat(ów).",
+  "keep_edit_failed": "Nie udało się zachować i edytować: {{error}}",
+  "other_duplicates_deleted": "Pozostałe duplikaty (zostaną usunięte)",
+  "append_translation": "+ tłumaczenie",
+  "append_all_translations": "Dodaj wszystkie tłumaczenia",
+  "save_and_keep": "Zapisz i zachowaj",
+  "categories_space_separated": "Oddzielone spacją"
 }


### PR DESCRIPTION
Two admin fixes.

## 1. Export includes ignored categories (bug)
"Download Phrases" used `get_phrases()`, which strips the language set's default-ignored categories — so e.g. HR-PL's *Gramatyka*/*Fraze* phrases were missing from the file. Switched the export to `get_phrases_for_admin()` (the same fetch the browse table uses), so the download contains **everything**.

## 2. "Keep & edit" when resolving duplicates (feature)
Duplicate Management previously only offered *Keep One* / *Merge Categories* — combining two synonym **translations** meant memorising the phrase and editing it in Browse Records. New third per-row action **Keep & edit** opens a dialog:
- pre-filled with that phrase's Phrase / Translation / Categories,
- lists the other duplicates (translation + categories) with a per-item and an **Append all translations** helper (joins with `; `, skipping exact repeats),
- on save: updates the kept phrase and deletes the others in one go.

FE-only — reuses the existing `PUT /admin/row/{id}` and duplicate-delete endpoints. Added en/pl/hr strings.

## Testing
- Backend: 350 tests pass (export tests updated to the admin fetch); ruff clean.
- Frontend: 456 pass incl. 5 new `KeepAndEditDialog` tests (prefill, list, append-all-skips-dupes, save payload, disabled state); lint + build clean.
- Real browser (Firefox), end to end:
  - Export CSV now contains the ignored-category phrase.
  - Keep & edit: translation `hi` → **append all** → `hi; hallo`, save → group resolved, DB left with a single `privit` row carrying the combined `hi; hallo`.