### PR TITLE
fix: opt e2e smoke sessions out of Training so it stops eating clicks

### DIFF
--- a/frontend/e2e/tests/helpers.js
+++ b/frontend/e2e/tests/helpers.js
@@ -13,6 +13,12 @@ export async function seedBrowser(page) {
       // Suppress the "What's New" modal — it auto-opens for logged-in users on a new
       // version and would otherwise intercept clicks on the grid.
       localStorage.setItem('lastSeenVersion', '999.0.0');
+      // Training defaults on for logged-in users and opens a "How well did you know
+      // it?" rating dialog after every find/solve — a real feature, but it's a modal
+      // that blocks further grid clicks, and these specs are testing the underlying
+      // find/solve mechanic, not the rating flow. Opt this session out so the smoke
+      // path stays uninterrupted (the rating dialog itself deserves its own test).
+      localStorage.setItem('osmosmjerkaTrainingMode', 'false');
     },
     { token: TOKEN, lang: LANG }
   );


### PR DESCRIPTION
## Summary
- The arcade-scoring removal (#227) made Training default **on** for logged-in users, which now pops a "How well did you know it?" rating dialog (modal) after every find/solve.
- `seedBrowser()` in the e2e specs simulates a logged-in user via a localStorage token, so both specs started hitting that dialog after the first word — it then intercepted every subsequent click on the grid, timing out `crossword.spec.js` entirely and truncating `wordsearch.spec.js`'s found-cell count.
- Fix: `seedBrowser()` now also sets `osmosmjerkaTrainingMode=false` before the app boots, same pattern already used there to suppress the "What's New" modal for the same reason. These specs test the underlying find/solve mechanic, not the rating flow — that deserves its own dedicated test later.
