### PR TITLE
Add crossword export (PNG/DOCX)

### DIFF
--- a/backend/osmosmjerka/game_api/export.py
+++ b/backend/osmosmjerka/game_api/export.py
@@ -18,18 +18,23 @@ async def export_puzzle(body: ExportPuzzleRequest) -> StreamingResponse:
     """Export puzzle in specified format (docx or png)"""
     try:
         if body.format == "docx":
-            content = export_to_docx(body.category, body.grid, body.phrases)
+            content = export_to_docx(
+                body.category, body.grid, body.phrases, body.game_type, body.across_label, body.down_label
+            )
             media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             extension = "docx"
         elif body.format == "png":
-            content = export_to_png(body.category, body.grid, body.phrases)
+            content = export_to_png(
+                body.category, body.grid, body.phrases, body.game_type, body.across_label, body.down_label
+            )
             media_type = "image/png"
             extension = "png"
         else:
             raise HTTPException(status_code=400, detail="Unsupported export format")
 
-        safe_category = re.sub(r"[^a-z0-9]+", "_", (body.category or "wordsearch").lower())
-        filename = f"wordsearch-{safe_category}.{extension}"
+        prefix = "crossword" if body.game_type == "crossword" else "wordsearch"
+        safe_category = re.sub(r"[^a-z0-9]+", "_", (body.category or prefix).lower())
+        filename = f"{prefix}-{safe_category}.{extension}"
 
         return StreamingResponse(
             io.BytesIO(content),

--- a/backend/osmosmjerka/game_api/schemas.py
+++ b/backend/osmosmjerka/game_api/schemas.py
@@ -66,9 +66,12 @@ class ExportPuzzleRequest(BaseModel):
     """Request model for exporting a puzzle."""
 
     category: str
-    grid: list[Any]  # 2D grid of characters
+    grid: list[Any]  # 2D grid of characters (crossword cells may be null)
     phrases: list[Any]  # Can be strings or dicts with phrase/translation
     format: str = Field(default="docx", pattern="^(docx|png)$")
+    game_type: str = Field(default="word_search", pattern="^(word_search|crossword)$")
+    across_label: str = Field(default="Across", max_length=50)
+    down_label: str = Field(default="Down", max_length=50)
 
 
 # ===== Game Sessions =====

--- a/backend/osmosmjerka/utils.py
+++ b/backend/osmosmjerka/utils.py
@@ -3,6 +3,8 @@ from io import BytesIO
 from docx import Document
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
 from docx.shared import Cm, Pt
 from osmosmjerka.logging_config import get_logger
 from PIL import Image, ImageDraw, ImageFont
@@ -10,19 +12,119 @@ from PIL import Image, ImageDraw, ImageFont
 logger = get_logger(__name__)
 
 
-def export_to_docx(category: str, grid: list, phrases: list) -> bytes:
-    """Export the phrase search grid and phrases to a DOCX file.
+def _shade_cell(cell_obj, fill_hex: str, pattern: str = "clear", pattern_color: str = "auto") -> None:
+    """Set a table cell's background fill/pattern (used for crossword blank/blocked cells)."""
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), pattern)
+    shd.set(qn("w:color"), pattern_color)
+    shd.set(qn("w:fill"), fill_hex)
+    cell_obj._tc.get_or_add_tcPr().append(shd)
+
+
+def _crop_crossword_grid(grid: list) -> tuple[list, int, int]:
+    """Trim a crossword grid down to its used content plus a 1-cell border.
+
+    The generator always allocates a grid sized for the longest word (at least
+    10x10), so a puzzle using only a handful of short phrases can leave most of
+    the grid empty. Exporting that full allocation makes for a mostly-blank,
+    oversized image/table, so this crops to the bounding box of placed letters.
+
+    Returns (cropped_grid, row_offset, col_offset) — the offsets to add to a
+    cropped cell's (row, col) to recover its coordinates in the original grid,
+    needed to look up clue-start numbers (keyed by original coordinates).
+    """
+    rows_with_content = [r for r, row in enumerate(grid) if any(cell is not None for cell in row)]
+    if not rows_with_content:
+        return grid, 0, 0
+    cols_with_content = [c for row in grid for c, cell in enumerate(row) if cell is not None]
+
+    pad = 1
+    min_r = max(0, min(rows_with_content) - pad)
+    max_r = min(len(grid) - 1, max(rows_with_content) + pad)
+    min_c = max(0, min(cols_with_content) - pad)
+    max_c = min(len(grid[0]) - 1, max(cols_with_content) + pad)
+
+    cropped = [row[min_c : max_c + 1] for row in grid[min_r : max_r + 1]]
+    return cropped, min_r, min_c
+
+
+def _crossword_start_numbers(phrases: list) -> dict:
+    """Map (row, col) -> clue number label for each phrase's starting cell.
+
+    When multiple phrases start at the same cell, their numbers are joined with
+    "/" (e.g. "1/2"), matching the live crossword grid's numbering.
+    """
+    numbers: dict[tuple[int, int], list] = {}
+    for p in phrases:
+        coords = p.get("coords")
+        number = p.get("start_number")
+        if coords and number:
+            r, c = coords[0]
+            numbers.setdefault((r, c), []).append(number)
+    return {key: "/".join(str(n) for n in nums) for key, nums in numbers.items()}
+
+
+def _crossword_clues(phrases: list) -> tuple[list[str], list[str]]:
+    """Build numbered "Across"/"Down" clue lines from placed crossword phrases.
+
+    The clue text is the translation (the puzzle-solver never sees the answer word
+    itself), matching how clues are shown in the live crossword UI.
+    """
+
+    def clue_text(p: dict) -> str:
+        return f"{p.get('start_number')}. {p.get('translation') or p.get('phrase', '')}"
+
+    across = sorted((p for p in phrases if p.get("direction") == "across"), key=lambda p: p.get("start_number") or 0)
+    down = sorted((p for p in phrases if p.get("direction") == "down"), key=lambda p: p.get("start_number") or 0)
+    return [clue_text(p) for p in across], [clue_text(p) for p in down]
+
+
+def _add_docx_clue_section(doc: Document, label: str, lines: list[str]) -> None:
+    if not lines:
+        return
+    heading = doc.add_paragraph()
+    heading_run = heading.add_run(label.upper())
+    heading_run.bold = True
+    heading_run.font.size = Pt(13)
+    for line in lines:
+        p = doc.add_paragraph(line)
+        for run in p.runs:
+            run.font.name = "Arial"
+            run.font.size = Pt(11)
+
+
+def export_to_docx(
+    category: str,
+    grid: list,
+    phrases: list,
+    game_type: str = "word_search",
+    across_label: str = "Across",
+    down_label: str = "Down",
+) -> bytes:
+    """Export the puzzle grid and phrases to a DOCX file.
 
     Args:
-        category (str): The category of the phrase search.
-        grid (list): The phrase search grid as a list of lists.
+        category (str): The category of the puzzle.
+        grid (list): The puzzle grid as a list of lists. Cells may be `None` for
+            crossword blank/blocked squares, which are rendered as shaded cells.
         phrases (list): A list of dictionaries with "phrase" and "translation" keys.
+            Crossword phrases additionally carry "coords", "direction", "start_number".
+        game_type (str): "word_search" or "crossword". Word search exports the
+            fully solved grid (all letters shown, as in normal play). Crossword
+            exports a blank, printable puzzle: numbered cells with no letters,
+            paired with a numbered Across/Down clue list.
+        across_label (str): Localized "Across" heading, used only for crosswords.
+        down_label (str): Localized "Down" heading, used only for crosswords.
 
     Returns:
         bytes: The DOCX file content as bytes.
     """
     if not category or not grid or not phrases:
         raise ValueError("Category, grid, and phrases must be provided.")
+    is_crossword = game_type == "crossword"
+    row_offset = col_offset = 0
+    if is_crossword:
+        grid, row_offset, col_offset = _crop_crossword_grid(grid)
     doc = Document()
     # Uppercase header with category name, centered
     heading = doc.add_heading(category.upper(), 0)
@@ -38,46 +140,136 @@ def export_to_docx(category: str, grid: list, phrases: list) -> bytes:
     for border in tbl.xpath(".//w:tblBorders"):
         border.getparent().remove(border)
 
-    # Set the cell width and height to 0.8 cm
+    cell_dim = Cm(1.0) if is_crossword else Cm(0.8)
+    numbers = _crossword_start_numbers(phrases) if is_crossword else {}
+
     for r, row in enumerate(grid):
         for c, cell in enumerate(row):
             cell_obj = table.cell(r, c)
-            cell_obj.text = cell
-            cell_obj.width = Cm(0.8)
-            for p in cell_obj.paragraphs:
-                p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-                for run in p.runs:
-                    run.font.name = "Courier New"
-                    run.font.size = Pt(12)
-                    run.bold = True  # Make grid letters bold
+            cell_obj.width = cell_dim
+            if cell is None:
+                if is_crossword:
+                    # Gray diagonal-stripe pattern for non-playable squares.
+                    _shade_cell(cell_obj, "D9D9D9", pattern="diagStripe", pattern_color="808080")
+                else:
+                    _shade_cell(cell_obj, "000000")
+                continue
+            p = cell_obj.paragraphs[0]
+            p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+            number = numbers.get((r + row_offset, c + col_offset))
+            if number:
+                num_run = p.add_run(number)
+                num_run.font.superscript = True
+                num_run.font.name = "Arial"
+                num_run.font.size = Pt(6)
+            if is_crossword:
+                # A crossword is exported blank, for solving on paper — the answer
+                # letters aren't shown, only the clue numbers.
+                continue
+            letter_run = p.add_run(cell)
+            letter_run.font.name = "Courier New"
+            letter_run.font.size = Pt(12)
+            letter_run.bold = True  # Make grid letters bold
 
     # Set row height for uniform appearance
     for row in table.rows:
-        row.height = Cm(0.8)
+        row.height = cell_dim
 
     doc.add_paragraph()  # Add a blank line for spacing
 
-    # Convert phrases to uppercase and join them with commas
-    phrases_line = ", ".join(w["phrase"].upper() for w in phrases)
-    p = doc.add_paragraph(phrases_line)
-    p.alignment = WD_ALIGN_PARAGRAPH.CENTER
-    for run in p.runs:
-        run.font.name = "Arial"
-        run.font.size = Pt(11)
-        run.bold = True  # Make phrases bold
+    if is_crossword:
+        across_lines, down_lines = _crossword_clues(phrases)
+        _add_docx_clue_section(doc, across_label, across_lines)
+        _add_docx_clue_section(doc, down_label, down_lines)
+    else:
+        # Convert phrases to uppercase and join them with commas
+        phrases_line = ", ".join(w["phrase"].upper() for w in phrases)
+        p = doc.add_paragraph(phrases_line)
+        p.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        for run in p.runs:
+            run.font.name = "Arial"
+            run.font.size = Pt(11)
+            run.bold = True  # Make phrases bold
 
     output = BytesIO()
     doc.save(output)
     return output.getvalue()
 
 
-def export_to_png(category: str, grid: list, phrases: list) -> bytes:
-    """Export the phrase search grid and phrases to a PNG image.
+def _load_export_fonts(cell_size: int) -> dict:
+    try:
+        return {
+            "title": ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", 24),
+            "grid": ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", max(18, cell_size // 2)),
+            "phrases": ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", 16),
+            "header": ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", 18),
+            "number": ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", max(10, cell_size // 3)),
+        }
+    except OSError:
+        try:
+            return {
+                "title": ImageFont.truetype("fonts/arialbd.ttf", 24),
+                "grid": ImageFont.truetype("fonts/arialbd.ttf", max(18, cell_size // 2)),
+                "phrases": ImageFont.truetype("fonts/arialbd.ttf", 16),
+                "header": ImageFont.truetype("fonts/arialbd.ttf", 18),
+                "number": ImageFont.truetype("fonts/arialbd.ttf", max(10, cell_size // 3)),
+            }
+        except OSError:
+            logger.warning("Could not load custom fonts, falling back to default font")
+            default = ImageFont.load_default()
+            return dict.fromkeys(("title", "grid", "phrases", "header", "number"), default)
+
+
+def _wrap_text_line(draw: ImageDraw.ImageDraw, text: str, font, max_width: int) -> list[str]:
+    words = text.split(" ")
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        test = f"{current} {word}".strip()
+        bbox = draw.textbbox((0, 0), test, font=font)
+        if bbox[2] - bbox[0] <= max_width or not current:
+            current = test
+        else:
+            lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines
+
+
+def _draw_blank_cell(draw: ImageDraw.ImageDraw, x: int, y: int, cell_size: int) -> None:
+    """Gray diagonal-stripe pattern for a crossword's non-playable squares."""
+    draw.rectangle([x, y, x + cell_size, y + cell_size], fill="#d9d9d9", outline="black", width=1)
+    spacing = 6
+    for offset in range(-cell_size, cell_size, spacing):
+        x0, y0 = x + max(0, offset), y + max(0, -offset)
+        x1, y1 = x + min(cell_size, offset + cell_size), y + min(cell_size, -offset + cell_size)
+        if x0 < x1 and y0 < y1:
+            draw.line([x0, y0, x1, y1], fill="#888888", width=1)
+
+
+def export_to_png(
+    category: str,
+    grid: list,
+    phrases: list,
+    game_type: str = "word_search",
+    across_label: str = "Across",
+    down_label: str = "Down",
+) -> bytes:
+    """Export the puzzle grid and phrases to a PNG image.
 
     Args:
-        category (str): The category of the phrase search.
-        grid (list): The phrase search grid as a list of lists.
+        category (str): The category of the puzzle.
+        grid (list): The puzzle grid as a list of lists. Cells may be `None` for
+            crossword blank/blocked squares, rendered as a gray diagonal-stripe pattern.
         phrases (list): A list of dictionaries with "phrase" and "translation" keys.
+            Crossword phrases additionally carry "coords", "direction", "start_number".
+        game_type (str): "word_search" or "crossword". Word search exports the
+            fully solved grid (all letters shown, as in normal play). Crossword
+            exports a blank, printable puzzle: numbered cells with no letters,
+            paired with a numbered Across/Down clue list.
+        across_label (str): Localized "Across" heading, used only for crosswords.
+        down_label (str): Localized "Down" heading, used only for crosswords.
 
     Returns:
         bytes: The PNG file content as bytes.
@@ -85,92 +277,131 @@ def export_to_png(category: str, grid: list, phrases: list) -> bytes:
     if not category or not grid or not phrases:
         raise ValueError("Category, grid, and phrases must be provided.")
 
-    grid_size = len(grid)
-    cell_size = max(30, min(50, 800 // grid_size))  # Adaptive cell size
+    is_crossword = game_type == "crossword"
+    row_offset = col_offset = 0
+    if is_crossword:
+        grid, row_offset, col_offset = _crop_crossword_grid(grid)
+
+    grid_rows = len(grid)
+    grid_cols = len(grid[0])
+    cell_size = max(30, min(50, 800 // max(grid_rows, grid_cols)))  # Adaptive cell size
     margin = 50
     title_height = 60
-    phrases_height = 100
-    grid_width = grid_size * cell_size
-    grid_height = grid_size * cell_size
-    image_width = grid_width + (2 * margin)
+    grid_width = grid_cols * cell_size
+    grid_height = grid_rows * cell_size
+    image_width = max(grid_width + (2 * margin), 700) if is_crossword else grid_width + (2 * margin)
+
+    fonts = _load_export_fonts(cell_size)
+    numbers = _crossword_start_numbers(phrases) if is_crossword else {}
+
+    # Crossword clue lines (numbered, split Across/Down) need to be measured and
+    # word-wrapped up front so the image can be sized to fit them, unlike word
+    # search's short comma-joined phrase list which fits a fixed-height footer.
+    measurer = ImageDraw.Draw(Image.new("RGB", (1, 1)))
+    line_height = 22
+    render_lines: list[tuple[str, str]] = []  # (text, "header" | "clue")
+    if is_crossword:
+        max_clue_width = image_width - (2 * margin)
+        across_lines, down_lines = _crossword_clues(phrases)
+        for label, lines in ((across_label, across_lines), (down_label, down_lines)):
+            if not lines:
+                continue
+            render_lines.append((label.upper(), "header"))
+            for line in lines:
+                for wrapped in _wrap_text_line(measurer, line, fonts["phrases"], max_clue_width):
+                    render_lines.append((wrapped, "clue"))
+        phrases_height = 30 + len(render_lines) * line_height + 8
+    else:
+        phrases_height = 100
+
     image_height = grid_height + title_height + phrases_height + (2 * margin)
     img = Image.new("RGB", (image_width, image_height), "white")
     draw = ImageDraw.Draw(img)
 
-    # Try to use a font with UTF-8 support (DejaVuSans)
-    try:
-        title_font = ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", 24)
-        grid_font = ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", max(18, cell_size // 2))
-        phrases_font = ImageFont.truetype("fonts/DejaVuSans-Bold.ttf", 16)
-    except OSError:
-        try:
-            title_font = ImageFont.truetype("fonts/arialbd.ttf", 24)
-            grid_font = ImageFont.truetype("fonts/arialbd.ttf", max(18, cell_size // 2))
-            phrases_font = ImageFont.truetype("fonts/arialbd.ttf", 16)
-        except OSError:
-            logger.warning("Could not load custom fonts, falling back to default font")
-            title_font = ImageFont.load_default()
-            grid_font = ImageFont.load_default()
-            phrases_font = ImageFont.load_default()
-
     # Draw title
     title_text = category.upper()
-    title_bbox = draw.textbbox((0, 0), title_text, font=title_font)
+    title_bbox = draw.textbbox((0, 0), title_text, font=fonts["title"])
     title_width = title_bbox[2] - title_bbox[0]
     title_x = (image_width - title_width) // 2
-    draw.text((title_x, margin), title_text, fill="black", font=title_font)
+    draw.text((title_x, margin), title_text, fill="black", font=fonts["title"])
 
     # Draw grid
     grid_start_y = margin + title_height
-    grid_start_x = margin
+    grid_start_x = (image_width - grid_width) // 2
 
     for i, row in enumerate(grid):
         for j, cell in enumerate(row):
             x = grid_start_x + (j * cell_size)
             y = grid_start_y + (i * cell_size)
 
+            if cell is None:
+                if is_crossword:
+                    _draw_blank_cell(draw, x, y, cell_size)
+                else:
+                    draw.rectangle([x, y, x + cell_size, y + cell_size], fill="black")
+                continue
+
             # Draw cell border
             draw.rectangle([x, y, x + cell_size, y + cell_size], outline="black", width=1)
 
+            if is_crossword:
+                # A crossword is exported blank, for solving on paper — the answer
+                # letters aren't shown, only the clue numbers.
+                number = numbers.get((i + row_offset, j + col_offset))
+                if number:
+                    draw.text((x + 2, y + 1), number, fill="black", font=fonts["number"])
+                continue
+
             # Draw cell text
-            text_bbox = draw.textbbox((0, 0), cell, font=grid_font)
+            text_bbox = draw.textbbox((0, 0), cell, font=fonts["grid"])
             text_width = text_bbox[2] - text_bbox[0]
             text_height = text_bbox[3] - text_bbox[1]
             text_x = x + (cell_size - text_width) // 2
             text_y = y + (cell_size - text_height) // 2
-            draw.text((text_x, text_y), cell, fill="black", font=grid_font)
+            draw.text((text_x, text_y), cell, fill="black", font=fonts["grid"])
 
-    # Draw phrases
-    phrases_text = ", ".join(w["phrase"].upper() for w in phrases)
     phrases_y = grid_start_y + grid_height + 30
 
-    # Split phrases into multiple lines if too long
-    max_width = image_width - (2 * margin)
-    phrases_lines = []
-    current_line = ""
+    if is_crossword:
+        y_cursor = phrases_y
+        first = True
+        for text, kind in render_lines:
+            if kind == "header":
+                if not first:
+                    y_cursor += 8
+                draw.text((margin, y_cursor), text, fill="black", font=fonts["header"])
+            else:
+                draw.text((margin, y_cursor), text, fill="black", font=fonts["phrases"])
+            y_cursor += line_height
+            first = False
+    else:
+        # Draw phrases, centered, wrapped into multiple comma-joined lines
+        phrases_text = ", ".join(w["phrase"].upper() for w in phrases)
+        max_width = image_width - (2 * margin)
+        phrases_lines = []
+        current_line = ""
 
-    for phrase in phrases_text.split(", "):
-        test_line = current_line + (", " if current_line else "") + phrase
-        test_bbox = draw.textbbox((0, 0), test_line, font=phrases_font)
-        test_width = test_bbox[2] - test_bbox[0]
+        for phrase in phrases_text.split(", "):
+            test_line = current_line + (", " if current_line else "") + phrase
+            test_bbox = draw.textbbox((0, 0), test_line, font=fonts["phrases"])
+            test_width = test_bbox[2] - test_bbox[0]
 
-        if test_width <= max_width:
-            current_line = test_line
-        else:
-            if current_line:
-                phrases_lines.append(current_line)
-            current_line = phrase
+            if test_width <= max_width:
+                current_line = test_line
+            else:
+                if current_line:
+                    phrases_lines.append(current_line)
+                current_line = phrase
 
-    if current_line:
-        phrases_lines.append(current_line)
+        if current_line:
+            phrases_lines.append(current_line)
 
-    # Draw each line of phrases
-    for i, line in enumerate(phrases_lines):
-        line_bbox = draw.textbbox((0, 0), line, font=phrases_font)
-        line_width = line_bbox[2] - line_bbox[0]
-        line_x = (image_width - line_width) // 2
-        line_y = phrases_y + (i * 20)
-        draw.text((line_x, line_y), line, fill="black", font=phrases_font)
+        for i, line in enumerate(phrases_lines):
+            line_bbox = draw.textbbox((0, 0), line, font=fonts["phrases"])
+            line_width = line_bbox[2] - line_bbox[0]
+            line_x = (image_width - line_width) // 2
+            line_y = phrases_y + (i * 20)
+            draw.text((line_x, line_y), line, fill="black", font=fonts["phrases"])
 
     # Save to BytesIO
     buffer = BytesIO()

--- a/backend/tests/test_game_api.py
+++ b/backend/tests/test_game_api.py
@@ -255,6 +255,26 @@ def test_export_puzzle_png(mock_export_png, client):
     assert "attachment; filename=wordsearch-test.png" in response.headers["content-disposition"]
 
 
+@patch("osmosmjerka.game_api.export.export_to_docx")
+def test_export_puzzle_crossword_docx(mock_export_docx, client):
+    """Test exporting a crossword puzzle uses the crossword filename prefix"""
+    mock_export_docx.return_value = b"docx_content"
+
+    data = {
+        "category": "Test",
+        "grid": [["A", None]],
+        "phrases": [{"phrase": "A", "translation": "A"}],
+        "format": "docx",
+        "game_type": "crossword",
+        "across_label": "Vodoravno",
+        "down_label": "Okomito",
+    }
+    response = client.post("/api/export", json=data)
+    assert response.status_code == 200
+    assert "attachment; filename=crossword-test.docx" in response.headers["content-disposition"]
+    mock_export_docx.assert_called_once_with("Test", [["A", None]], data["phrases"], "crossword", "Vodoravno", "Okomito")
+
+
 def test_export_puzzle_default_format(client):
     """Test exporting puzzle with default DOCX format"""
     with patch("osmosmjerka.game_api.export.export_to_docx") as mock_export:

--- a/backend/tests/test_game_api.py
+++ b/backend/tests/test_game_api.py
@@ -272,7 +272,9 @@ def test_export_puzzle_crossword_docx(mock_export_docx, client):
     response = client.post("/api/export", json=data)
     assert response.status_code == 200
     assert "attachment; filename=crossword-test.docx" in response.headers["content-disposition"]
-    mock_export_docx.assert_called_once_with("Test", [["A", None]], data["phrases"], "crossword", "Vodoravno", "Okomito")
+    mock_export_docx.assert_called_once_with(
+        "Test", [["A", None]], data["phrases"], "crossword", "Vodoravno", "Okomito"
+    )
 
 
 def test_export_puzzle_default_format(client):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -101,3 +101,105 @@ def test_export_to_png_empty_phrases():
     grid = [["A"]]
     with pytest.raises(ValueError):
         export_to_png(category, grid, [])
+
+
+CROSSWORD_GRID = [["C", "A", "T"], [None, None, "O"], [None, None, "X"]]
+CROSSWORD_PHRASES = [
+    {"phrase": "cat", "translation": "kot", "coords": [[0, 0], [0, 1], [0, 2]], "direction": "across", "start_number": 1},
+    {"phrase": "tox", "translation": "tox", "coords": [[0, 2], [1, 2], [2, 2]], "direction": "down", "start_number": 2},
+]
+
+
+def test_export_to_docx_crossword_crops_oversized_allocation(tmp_path):
+    """A puzzle placed in a small corner of an oversized generator allocation should
+    export a small table, not a mostly-blank one matching the full allocation."""
+    size = 10
+    grid = [[None for _ in range(size)] for _ in range(size)]
+    grid[4][4], grid[4][5], grid[4][6] = "C", "A", "T"
+    phrases = [{"phrase": "cat", "translation": "kot", "coords": [[4, 4], [4, 5], [4, 6]], "direction": "across", "start_number": 1}]
+
+    docx_bytes = export_to_docx("Small", grid, phrases, game_type="crossword")
+    docx_file = tmp_path / "small_crossword.docx"
+    docx_file.write_bytes(docx_bytes)
+    from docx import Document
+
+    doc = Document(str(docx_file))
+    table = doc.tables[0]
+    assert len(table.rows) < size
+    assert len(table.columns) < size
+    # The clue number should still land on the right cell after cropping.
+    assert table.cell(1, 1).text == "1"
+
+
+def test_crop_crossword_grid_trims_unused_allocation():
+    """The generator always allocates a grid sized for the longest word (>=10x10),
+    so a puzzle using only a few short phrases leaves most of it empty. The export
+    should crop to the used content (plus a 1-cell border), not the full allocation."""
+    from osmosmjerka.utils import _crop_crossword_grid
+
+    size = 10
+    grid = [[None for _ in range(size)] for _ in range(size)]
+    # A tiny 3-letter word placed near the middle of the oversized allocation.
+    grid[4][4], grid[4][5], grid[4][6] = "C", "A", "T"
+
+    cropped, row_offset, col_offset = _crop_crossword_grid(grid)
+    assert len(cropped) < size
+    assert len(cropped[0]) < size
+    assert row_offset == 3  # one cell of padding above row 4
+    assert col_offset == 3  # one cell of padding left of col 4
+    # The letters should still be reachable at their offset-adjusted position.
+    assert cropped[4 - row_offset][4 - col_offset] == "C"
+
+
+def test_crossword_start_numbers_shared_cell():
+    """When two phrases start at the same cell, their numbers are joined with "/",
+    matching the live crossword grid's numbering convention."""
+    from osmosmjerka.utils import _crossword_start_numbers
+
+    phrases = [
+        {"coords": [[0, 0], [0, 1]], "direction": "across", "start_number": 1},
+        {"coords": [[0, 0], [1, 0]], "direction": "down", "start_number": 2},
+        {"coords": [[2, 2], [2, 3]], "direction": "across", "start_number": 3},
+    ]
+    numbers = _crossword_start_numbers(phrases)
+    assert numbers[(0, 0)] == "1/2"
+    assert numbers[(2, 2)] == "3"
+
+
+def test_export_to_docx_crossword_is_blank_with_clues(tmp_path):
+    """Crossword export is a blank, printable puzzle: numbered cells with no answer
+    letters, non-playable cells shaded, and a numbered Across/Down clue list (using
+    the translation, not the answer) instead of a plain word list."""
+    docx_bytes = export_to_docx("Crossword", CROSSWORD_GRID, CROSSWORD_PHRASES, game_type="crossword")
+    assert isinstance(docx_bytes, bytes)
+    docx_file = tmp_path / "crossword.docx"
+    docx_file.write_bytes(docx_bytes)
+    from docx import Document
+
+    doc = Document(str(docx_file))
+    assert doc.tables[0].cell(0, 0).text == "1"  # clue number only, no letter
+    assert doc.tables[0].cell(0, 1).text == ""  # playable but not a clue start: fully blank
+    assert doc.tables[0].cell(1, 0).text == ""  # blank/shaded cell, no text
+    body_text = "\n".join(p.text for p in doc.paragraphs)
+    assert "ACROSS" in body_text
+    assert "DOWN" in body_text
+    assert "1. kot" in body_text
+    assert "2. tox" in body_text
+    # The answer words themselves should not leak into the clue text or the grid
+    assert "1. cat" not in body_text
+    assert "cat" not in body_text.lower()
+
+
+def test_export_to_png_crossword_blank_cells(tmp_path):
+    """Crossword export is a blank puzzle: non-playable cells get a gray stripe
+    pattern, playable cells get numbers but no letters, plus an Across/Down clue list."""
+    from osmosmjerka.utils import export_to_png
+
+    png_bytes = export_to_png("Crossword", CROSSWORD_GRID, CROSSWORD_PHRASES, game_type="crossword")
+    assert isinstance(png_bytes, bytes)
+    png_file = tmp_path / "crossword.png"
+    png_file.write_bytes(png_bytes)
+    from PIL import Image
+
+    img = Image.open(str(png_file))
+    assert img.format == "PNG"

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -105,8 +105,20 @@ def test_export_to_png_empty_phrases():
 
 CROSSWORD_GRID = [["C", "A", "T"], [None, None, "O"], [None, None, "X"]]
 CROSSWORD_PHRASES = [
-    {"phrase": "cat", "translation": "kot", "coords": [[0, 0], [0, 1], [0, 2]], "direction": "across", "start_number": 1},
-    {"phrase": "tox", "translation": "tox", "coords": [[0, 2], [1, 2], [2, 2]], "direction": "down", "start_number": 2},
+    {
+        "phrase": "cat",
+        "translation": "kot",
+        "coords": [[0, 0], [0, 1], [0, 2]],
+        "direction": "across",
+        "start_number": 1,
+    },
+    {
+        "phrase": "tox",
+        "translation": "tox",
+        "coords": [[0, 2], [1, 2], [2, 2]],
+        "direction": "down",
+        "start_number": 2,
+    },
 ]
 
 
@@ -116,7 +128,15 @@ def test_export_to_docx_crossword_crops_oversized_allocation(tmp_path):
     size = 10
     grid = [[None for _ in range(size)] for _ in range(size)]
     grid[4][4], grid[4][5], grid[4][6] = "C", "A", "T"
-    phrases = [{"phrase": "cat", "translation": "kot", "coords": [[4, 4], [4, 5], [4, 6]], "direction": "across", "start_number": 1}]
+    phrases = [
+        {
+            "phrase": "cat",
+            "translation": "kot",
+            "coords": [[4, 4], [4, 5], [4, 6]],
+            "direction": "across",
+            "start_number": 1,
+        }
+    ]
 
     docx_bytes = export_to_docx("Small", grid, phrases, game_type="crossword")
     docx_file = tmp_path / "small_crossword.docx"

--- a/frontend/src/features/export/components/ExportButton.jsx
+++ b/frontend/src/features/export/components/ExportButton.jsx
@@ -7,7 +7,7 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import ExportModal from './ExportModal';
 import { useTranslation } from 'react-i18next';
 
-export default function ExportButton({ category, grid, phrases, disabled, className, sx }) {
+export default function ExportButton({ category, grid, phrases, gameType = 'word_search', disabled, className, sx }) {
     const [modalOpen, setModalOpen] = useState(false);
     const { t } = useTranslation();
 
@@ -15,12 +15,21 @@ export default function ExportButton({ category, grid, phrases, disabled, classN
         try {
             const response = await axios.post(
                 "/api/export",
-                { category, grid, phrases, format },
+                {
+                    category,
+                    grid,
+                    phrases,
+                    format,
+                    game_type: gameType,
+                    across_label: t('crossword.across'),
+                    down_label: t('crossword.down'),
+                },
                 { responseType: 'blob' }
             );
 
             const url = window.URL.createObjectURL(new Blob([response.data]));
-            const safeCategory = (category || t('wordsearch')).replace(/[^a-z0-9]+/gi, "_").toLowerCase();
+            const puzzleLabel = t(gameType === 'crossword' ? 'gameType.crossword' : 'wordsearch');
+            const safeCategory = (category || puzzleLabel).replace(/[^a-z0-9]+/gi, "_").toLowerCase();
 
             // Determine file extension based on format
             const extensions = {
@@ -31,7 +40,7 @@ export default function ExportButton({ category, grid, phrases, disabled, classN
 
             const link = document.createElement('a');
             link.href = url;
-            link.setAttribute('download', `${t('wordsearch')}-${safeCategory}.${extension}`);
+            link.setAttribute('download', `${puzzleLabel}-${safeCategory}.${extension}`);
             document.body.appendChild(link);
             link.click();
             link.remove();

--- a/frontend/src/features/export/components/__tests__/ExportButton.test.jsx
+++ b/frontend/src/features/export/components/__tests__/ExportButton.test.jsx
@@ -51,7 +51,42 @@ test('handles export with format selection', async () => {
     await waitFor(() => {
         expect(axios.post).toHaveBeenCalledWith(
             "/api/export",
-            { category: "TestCat", grid: [['A']], phrases: [{ phrase: 'test' }], format: 'docx' },
+            {
+                category: "TestCat",
+                grid: [['A']],
+                phrases: [{ phrase: 'test' }],
+                format: 'docx',
+                game_type: 'word_search',
+                across_label: 'Across',
+                down_label: 'Down',
+            },
+            { responseType: 'blob' }
+        );
+    });
+});
+
+test('sends crossword game_type and across/down labels when exporting a crossword puzzle', async () => {
+    const mockBlob = new Blob(['test data']);
+    axios.post.mockResolvedValue({ data: mockBlob });
+    render(withI18n(
+        <ExportButton category="TestCat" grid={[['A', null]]} phrases={[{ phrase: 'test' }]} gameType="crossword" />
+    ));
+    const btn = screen.getByRole('button', { name: /export/i });
+    fireEvent.click(btn);
+    const docxButton = screen.getByText(/word document/i);
+    fireEvent.click(docxButton);
+    await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+            "/api/export",
+            {
+                category: "TestCat",
+                grid: [['A', null]],
+                phrases: [{ phrase: 'test' }],
+                format: 'docx',
+                game_type: 'crossword',
+                across_label: 'Across',
+                down_label: 'Down',
+            },
             { responseType: 'blob' }
         );
     });

--- a/frontend/src/features/game/components/Controls/GameControls.jsx
+++ b/frontend/src/features/game/components/Controls/GameControls.jsx
@@ -134,17 +134,16 @@ const GameControls = ({
                         </Box>
                     </Button>
 
-                    {/* Export button - only for word search */}
-                    {gameType === 'word_search' && (
-                        <ExportButton
-                            category={selectedCategoryState}
-                            grid={grid}
-                            phrases={phrases}
-                            disabled={isLoading || grid.length === 0 || notEnoughPhrases}
-                            t={t}
-                            className="control-action-button"
-                        />
-                    )}
+                    {/* Export button */}
+                    <ExportButton
+                        category={selectedCategoryState}
+                        grid={grid}
+                        phrases={phrases}
+                        gameType={gameType}
+                        disabled={isLoading || grid.length === 0 || notEnoughPhrases}
+                        t={t}
+                        className="control-action-button"
+                    />
                 </Box>
             </Box>
         </>

--- a/frontend/src/features/game/components/Controls/__tests__/GameControls.test.jsx
+++ b/frontend/src/features/game/components/Controls/__tests__/GameControls.test.jsx
@@ -91,10 +91,10 @@ describe('GameControls disabled states', () => {
         expect(refreshButton).not.toBeDisabled();
     });
 
-    test('hides export button when gameType is crossword', () => {
+    test('shows export button when gameType is crossword', () => {
         renderControls({ gameType: 'crossword' });
-        const exportButton = screen.queryByTestId('export-button');
-        expect(exportButton).not.toBeInTheDocument();
+        const exportButton = screen.getByTestId('export-button');
+        expect(exportButton).toBeInTheDocument();
     });
 
     test('shows export button when gameType is word_search', () => {

--- a/helpers/e2e/seed.py
+++ b/helpers/e2e/seed.py
@@ -15,14 +15,14 @@ import urllib.request
 # with; also fine for the word-search grid. category;phrase;translation
 WORDS = [
     ("cat", "kot"), ("dog", "pies"), ("rat", "szczur"), ("bat", "nietoperz"),
-    ("owl", "sowa"), ("cow", "krowa"), ("ant", "mrowka"), ("bee", "pszczola"),
-    ("fox", "lis"), ("hen", "kura"), ("pig", "swinia"), ("ram", "baran"),
-    ("ape", "malpa"), ("elk", "los"), ("eel", "wegorz"), ("emu", "ptak"),
-    ("asp", "zmija"), ("sow", "maciora"), ("tan", "opalenizna"), ("tar", "smola"),
-    ("net", "siec"), ("ten", "dziesiec"), ("nap", "drzemka"), ("pan", "patelnia"),
+    ("owl", "sowa"), ("cow", "krowa"), ("ant", "mrówka"), ("bee", "pszczoła"),
+    ("fox", "lis"), ("hen", "kura"), ("pig", "świnia"), ("ram", "baran"),
+    ("ape", "małpa"), ("elk", "łoś"), ("eel", "węgorz"), ("emu", "ptak"),
+    ("asp", "żmija"), ("sow", "maciora"), ("tan", "opalenizna"), ("tar", "smoła"),
+    ("net", "sieć"), ("ten", "dziesięć"), ("nap", "drzemka"), ("pan", "patelnia"),
     ("ear", "ucho"), ("era", "epoka"), ("oat", "owies"), ("toe", "palec"),
-    ("eat", "jesc"), ("tea", "herbata"), ("ore", "ruda"), ("roe", "ikra"),
-    ("arc", "luk"), ("oar", "wioslo"), ("rot", "gnicie"),
+    ("eat", "jeść"), ("tea", "herbata"), ("ore", "ruda"), ("roe", "ikra"),
+    ("arc", "łuk"), ("oar", "wiosło"), ("rot", "gnicie"),
 ]
 
 


### PR DESCRIPTION
## Summary
- Extends the existing word-search Export (PNG/DOCX) to crosswords, rendered as a real printable puzzle: numbered cells (no answer letters), gray diagonal-stripe blocked squares, and a numbered Across/Down clue list using the translation
- Grid is cropped to the puzzle's actual footprint instead of the generator's full allocation
- Word-search export is unchanged
- Fixes missing Polish diacritics in `helpers/e2e/seed.py`'s fixture translations

## Test plan
- [x] Backend: 353 tests pass
- [x] Frontend: 415 tests pass
- [x] ruff check/format, eslint clean
- [x] Manually verified against a live crossword puzzle in-browser (PNG + DOCX)