### PR TITLE
Embed Review Sprint in My Study, self-provision a staging demo account

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ ADMIN_USERNAME=admin
 ADMIN_PASSWORD_HASH=<bcrypt_hash>  # See below for generation
 ADMIN_SECRET_KEY=<your_secret_key>  # Secret key for JWT token signing
 
+# Demo Account (optional)
+# Creates/refreshes a regular-user demo account on every startup — intended for a
+# staging/demo deployment only. Leave both unset (the default) to skip this entirely,
+# which is how a production deployment should be configured.
+DEMO_USERNAME=demo
+DEMO_PASSWORD_HASH=<bcrypt_hash>  # See below for generation
+
 # Database (required)
 POSTGRES_USER=osmosmjerka
 POSTGRES_PASSWORD=<db_password>
@@ -234,9 +241,9 @@ LOG_LEVEL=INFO              # Logging level: DEBUG, INFO, WARNING, ERROR, CRITIC
 LOG_COLORS=true             # Enable colored output in development mode (default: true)
 ```
 
-### Generate Admin Password Hash
+### Generate a Password Hash
 
-Use this command to create a bcrypt password hash:
+Use this command to create a bcrypt password hash (for `ADMIN_PASSWORD_HASH` or `DEMO_PASSWORD_HASH`):
 
 ```bash
 python3 -c "import bcrypt; import getpass; pwd=getpass.getpass('Password: ').encode(); print(bcrypt.hashpw(pwd, bcrypt.gensalt()).decode())"

--- a/backend/osmosmjerka/app.py
+++ b/backend/osmosmjerka/app.py
@@ -48,6 +48,11 @@ STATIC_FILE_EXTENSIONS = [
 DEVELOPMENT_MODE = os.getenv("DEVELOPMENT_MODE", "false").lower() == "true"
 FRONTEND_DEV_URL = "http://localhost:3210"
 
+# Optional demo account, meant for the staging environment only. Unset in prod (and by
+# default everywhere), so this is a no-op there. See ensure_demo_account() below.
+DEMO_USERNAME = os.getenv("DEMO_USERNAME", "")
+DEMO_PASSWORD_HASH = os.getenv("DEMO_PASSWORD_HASH", "")
+
 # Request size limits (in bytes)
 MAX_REQUEST_SIZE = int(os.getenv("MAX_REQUEST_SIZE", str(2 * 1024 * 1024)))  # 2MB default
 
@@ -122,6 +127,37 @@ def ensure_root_admin_account():
     return _ensure
 
 
+def ensure_demo_account():
+    """Create/refresh an optional demo account from DEMO_USERNAME/DEMO_PASSWORD_HASH.
+
+    Meant for the staging environment, whose DB is periodically overwritten with a
+    fresh clone of prod's (see the GitOps deploy pipeline) — running this on every
+    startup makes the demo account self-healing across those clones instead of a
+    one-off manual insert that the next deploy would silently wipe out. Prod (and any
+    environment that simply doesn't set these two env vars) never gets a demo account,
+    so this never puts one in front of real users.
+    """
+
+    async def _ensure():
+        if not (DEMO_USERNAME and DEMO_PASSWORD_HASH):
+            return
+
+        existing = await db_manager.get_account_by_username(DEMO_USERNAME)
+        if not existing:
+            await db_manager.create_account(
+                username=DEMO_USERNAME,
+                password_hash=DEMO_PASSWORD_HASH,
+                role="regular",
+                self_description="Demo account",
+            )
+            return
+
+        if existing.get("password_hash") != DEMO_PASSWORD_HASH:
+            await db_manager.update_account(existing["id"], password_hash=DEMO_PASSWORD_HASH)
+
+    return _ensure
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     logger.info("Application startup initiated")
@@ -131,6 +167,12 @@ async def lifespan(_: FastAPI):
 
         await ensure_root_admin_account()()
         logger.info("Root admin account verified")
+
+        await ensure_demo_account()()
+        if DEMO_USERNAME and DEMO_PASSWORD_HASH:
+            logger.info("Demo account verified")
+        else:
+            logger.info("Demo account not configured (skipped)")
 
         logger.info("Application ready to accept requests")
     except Exception as e:

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,10 +1,13 @@
 # isort: skip_file
 import sys
+from unittest.mock import AsyncMock
+
 import pytest
 
 import starlette.staticfiles
 
-from osmosmjerka.app import app
+import osmosmjerka.app as app_module
+from osmosmjerka.app import app, ensure_demo_account
 from fastapi.testclient import TestClient
 
 
@@ -80,3 +83,64 @@ def test_get_grid_size_and_num_phrases_function():
     # Test unknown difficulty defaults to easy
     size, num_phrases = get_grid_size_and_num_phrases([{"phrase": "a"}] * 10, "unknown")
     assert size == 10 and num_phrases == 7
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_account_noop_when_unconfigured(monkeypatch):
+    """Prod (and any env that just doesn't set these two vars) must never get a demo account."""
+    monkeypatch.setattr(app_module, "DEMO_USERNAME", "")
+    monkeypatch.setattr(app_module, "DEMO_PASSWORD_HASH", "")
+    mock_db = AsyncMock()
+    monkeypatch.setattr(app_module, "db_manager", mock_db)
+
+    await ensure_demo_account()()
+
+    mock_db.get_account_by_username.assert_not_called()
+    mock_db.create_account.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_account_creates_when_missing(monkeypatch):
+    monkeypatch.setattr(app_module, "DEMO_USERNAME", "demo")
+    monkeypatch.setattr(app_module, "DEMO_PASSWORD_HASH", "hashed-demo-pw")
+    mock_db = AsyncMock()
+    mock_db.get_account_by_username.return_value = None
+    monkeypatch.setattr(app_module, "db_manager", mock_db)
+
+    await ensure_demo_account()()
+
+    mock_db.create_account.assert_called_once_with(
+        username="demo",
+        password_hash="hashed-demo-pw",
+        role="regular",
+        self_description="Demo account",
+    )
+    mock_db.update_account.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_account_refreshes_stale_password_hash(monkeypatch):
+    monkeypatch.setattr(app_module, "DEMO_USERNAME", "demo")
+    monkeypatch.setattr(app_module, "DEMO_PASSWORD_HASH", "new-hash")
+    mock_db = AsyncMock()
+    mock_db.get_account_by_username.return_value = {"id": 7, "password_hash": "old-hash"}
+    monkeypatch.setattr(app_module, "db_manager", mock_db)
+
+    await ensure_demo_account()()
+
+    mock_db.create_account.assert_not_called()
+    mock_db.update_account.assert_called_once_with(7, password_hash="new-hash")
+
+
+@pytest.mark.asyncio
+async def test_ensure_demo_account_leaves_matching_account_untouched(monkeypatch):
+    monkeypatch.setattr(app_module, "DEMO_USERNAME", "demo")
+    monkeypatch.setattr(app_module, "DEMO_PASSWORD_HASH", "same-hash")
+    mock_db = AsyncMock()
+    mock_db.get_account_by_username.return_value = {"id": 7, "password_hash": "same-hash"}
+    monkeypatch.setattr(app_module, "db_manager", mock_db)
+
+    await ensure_demo_account()()
+
+    mock_db.create_account.assert_not_called()
+    mock_db.update_account.assert_not_called()

--- a/frontend/e2e/tests/demo-account.spec.js
+++ b/frontend/e2e/tests/demo-account.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// Exercises the actual login form (not a localStorage-injected token, unlike the other
+// specs) against the demo account that DEMO_USERNAME/DEMO_PASSWORD_HASH self-provisions
+// on backend startup — the same mechanism staging uses. Confirms it logs in as a plain
+// "regular" user, not anything privileged.
+const DEMO_USERNAME = process.env.E2E_DEMO_USERNAME;
+const DEMO_PASSWORD = process.env.E2E_DEMO_PASSWORD;
+
+test('demo account: logs in through the real form as a non-privileged regular user', async ({ page }) => {
+  test.skip(!DEMO_USERNAME || !DEMO_PASSWORD, 'E2E_DEMO_USERNAME/E2E_DEMO_PASSWORD not set for this run');
+
+  await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+
+  await page.getByPlaceholder('Username').fill(DEMO_USERNAME);
+  await page.getByPlaceholder('Password').fill(DEMO_PASSWORD);
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  // Exact role assertion via the dashboard's own "Welcome, {{username}} ({{role}})" copy.
+  await expect(page.getByText(`Welcome, ${DEMO_USERNAME} (regular)`)).toBeVisible({ timeout: 10_000 });
+
+  // Available to every logged-in user...
+  await expect(page.getByRole('button', { name: 'My Study' })).toBeVisible();
+  // ...but root_admin/administrative-only tools must not appear for a regular account.
+  await expect(page.getByRole('button', { name: 'Statistics Dashboard' })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: /system settings/i })).not.toBeVisible();
+});

--- a/frontend/e2e/tests/my-study-review-sprint.spec.js
+++ b/frontend/e2e/tests/my-study-review-sprint.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { seedBrowser } from './helpers.js';
+
+// Review Sprint used to be reachable only as its own full-page route. It's now also
+// embedded as a third tab in My Study — confirm switching to it renders in place
+// (no navigation to a new URL) and that it actually mounts the widget.
+test('My Study: Review sprint tab embeds in place, without navigating to a new page', async ({ page }) => {
+  await seedBrowser(page);
+  await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+
+  await page.getByRole('button', { name: 'My Study' }).click();
+  const reviewTab = page.getByRole('tab', { name: /review sprint/i });
+  await reviewTab.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const urlBeforeTabClick = page.url();
+  await reviewTab.click();
+
+  expect(page.url()).toBe(urlBeforeTabClick);
+  // Stats row (Tracked/Due/Mastered) renders regardless of whether anything is due yet.
+  await expect(page.getByText(/tracked:/i)).toBeVisible({ timeout: 10_000 });
+});

--- a/frontend/src/features/admin/components/AdminPanel/MyStudy.jsx
+++ b/frontend/src/features/admin/components/AdminPanel/MyStudy.jsx
@@ -23,10 +23,12 @@ import {
     ExitToApp as LeaveIcon,
     Extension as PuzzleIcon,
     PlayArrow as PlayIcon,
+    Psychology as PsychologyIcon,
     School as SchoolIcon,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import ReviewSprintPanel from '../../../game/components/Review/ReviewSprintPanel';
 import { useStudentStudy } from './useStudentStudy';
 
 /**
@@ -137,6 +139,11 @@ export default function MyStudy({ token }) {
                         icon={<SchoolIcon />}
                         iconPosition="start"
                         label={t('student.study.groups_title', 'My Study Groups')}
+                    />
+                    <Tab
+                        icon={<PsychologyIcon />}
+                        iconPosition="start"
+                        label={t('review.title', 'Review sprint')}
                     />
                 </Tabs>
             </Box>
@@ -388,6 +395,15 @@ export default function MyStudy({ token }) {
                     </Box>
                 )
                 }
+            </div>
+
+            {/* Tab Panel: Review Sprint */}
+            <div role="tabpanel" hidden={tabValue !== 2}>
+                {tabValue === 2 && (
+                    <Box sx={{ py: 1 }}>
+                        <ReviewSprintPanel />
+                    </Box>
+                )}
             </div>
         </Paper>
     );

--- a/frontend/src/features/admin/components/AdminPanel/__tests__/MyStudy.test.jsx
+++ b/frontend/src/features/admin/components/AdminPanel/__tests__/MyStudy.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MyStudy from '../MyStudy';
+import { withI18n } from '../../../../../testUtils';
+
+jest.mock('../useStudentStudy', () => ({
+    useStudentStudy: () => ({
+        fetchMyGroups: jest.fn().mockResolvedValue([]),
+        fetchInvitations: jest.fn().mockResolvedValue([]),
+        fetchAssignedPuzzles: jest.fn().mockResolvedValue({ puzzles: [] }),
+        acceptInvitation: jest.fn(),
+        declineInvitation: jest.fn(),
+        leaveGroup: jest.fn(),
+    }),
+}));
+
+jest.mock('../../../../game/components/Review/ReviewSprintPanel', () => () => (
+    <div data-testid="review-sprint-panel">Review sprint panel</div>
+));
+
+const renderMyStudy = () =>
+    render(withI18n(
+        <MemoryRouter>
+            <MyStudy token="test-token" />
+        </MemoryRouter>
+    ));
+
+test('renders three tabs including Review sprint', async () => {
+    renderMyStudy();
+    await waitFor(() => expect(screen.getByRole('tab', { name: /assigned puzzles/i })).toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: /my study groups/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /review sprint/i })).toBeInTheDocument();
+});
+
+test('switching to the Review sprint tab embeds the panel in place, without navigating away', async () => {
+    renderMyStudy();
+    await waitFor(() => expect(screen.getByRole('tab', { name: /review sprint/i })).toBeInTheDocument());
+
+    expect(screen.queryByTestId('review-sprint-panel')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: /review sprint/i }));
+    expect(screen.getByTestId('review-sprint-panel')).toBeInTheDocument();
+    // Still on the My Study page — the tab switch doesn't navigate to a new view.
+    expect(screen.getByText('My Study')).toBeInTheDocument();
+});

--- a/frontend/src/features/game/components/Review/ReviewSprint.jsx
+++ b/frontend/src/features/game/components/Review/ReviewSprint.jsx
@@ -1,194 +1,25 @@
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import PsychologyIcon from "@mui/icons-material/Psychology";
-import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Container,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { useState } from "react";
+import { Box, Container, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../../../hooks/useAuth";
-import { useReviewSprint } from "../../../../hooks/useReviewSprint";
-import { useSystemPreferences } from "../../../../hooks/useSystemPreferences";
 import GameHeader from "../GameHeader/GameHeader";
-import ListenButton from "./ListenButton";
-import VoiceManager from "./VoiceManager";
-
-function StatsRow({ stats, t }) {
-  if (!stats) return null;
-  return (
-    <Stack direction="row" spacing={1} sx={{ justifyContent: "center", flexWrap: "wrap" }}>
-      {stats.streak > 0 && <Chip size="small" color="primary" label={`🔥 ${stats.streak}`} />}
-      <Chip size="small" label={`${t("review.tracked", "Tracked")}: ${stats.total ?? 0}`} />
-      <Chip size="small" color="warning" label={`${t("review.due", "Due")}: ${stats.due ?? 0}`} />
-      <Chip size="small" color="success" label={`${t("review.mastered", "Mastered")}: ${stats.mastered ?? 0}`} />
-    </Stack>
-  );
-}
+import ReviewSprintPanel from "./ReviewSprintPanel";
 
 export default function ReviewSprint() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { currentUser } = useAuth();
-  const [voicesOpen, setVoicesOpen] = useState(false);
-  const { ttsEnabled } = useSystemPreferences();
-  const { status, current, index, total, revealed, reveal, rate, stats, reviewedCount, startSprint } =
-    useReviewSprint();
-
-  const isProduction = current?.direction === "production";
-  // production: shown the meaning, recall the word. recognition: shown the word, recall the meaning.
-  const prompt = current ? (isProduction ? current.translation : current.phrase) : "";
-  const answer = current ? (isProduction ? current.phrase : current.translation) : "";
-  const promptLabel = isProduction
-    ? t("review.recallWord", "Recall the word")
-    : t("review.recallMeaning", "Recall the meaning");
-
-  const backButton = (
-    <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/")} sx={{ alignSelf: "flex-start" }}>
-      {t("review.backToGame", "Back to game")}
-    </Button>
-  );
 
   return (
     <>
       <GameHeader handleLogoClick={() => navigate("/")} currentUser={currentUser} />
       <Container maxWidth="sm" sx={{ py: 3 }}>
-        <Stack spacing={2} sx={{ alignItems: "center" }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, alignSelf: "center" }}>
-            <PsychologyIcon color="primary" />
-            <Typography variant="h5">{t("review.title", "Review sprint")}</Typography>
-          </Box>
-
-          {status === "loading" && <CircularProgress sx={{ my: 4 }} />}
-
-          {status === "unauthenticated" && (
-            <>
-              <Alert severity="info" sx={{ width: "100%" }}>
-                {t("review.loginRequired", "Log in to review your words and track mastery.")}
-              </Alert>
-              <Stack direction="row" spacing={1}>
-                <Button variant="contained" onClick={() => navigate("/admin")}>
-                  {t("login", "Login")}
-                </Button>
-                <Button onClick={() => navigate("/")}>{t("review.backToGame", "Back to game")}</Button>
-              </Stack>
-            </>
-          )}
-
-        {status === "error" && (
-          <>
-            <Typography color="error">{t("review.error", "Could not load your reviews.")}</Typography>
-            <Button variant="contained" onClick={startSprint}>
-              {t("review.retry", "Try again")}
-            </Button>
-            {backButton}
-          </>
-        )}
-
-        {status === "empty" && (
-          <>
-            <StatsRow stats={stats} t={t} />
-            <Typography sx={{ mt: 2 }}>
-              {t("review.nothingDue", "Nothing due right now — come back later! 🎉")}
-            </Typography>
-            {backButton}
-          </>
-        )}
-
-        {status === "done" && (
-          <>
-            <StatsRow stats={stats} t={t} />
-            <Typography variant="h6" sx={{ mt: 2 }}>
-              {t("review.sprintDone", "Sprint complete!")}
-            </Typography>
-            <Typography color="text.secondary">
-              {t("review.reviewedCount", "Reviewed {{count}} words", { count: reviewedCount })}
-            </Typography>
-            <Stack direction="row" spacing={1}>
-              <Button variant="contained" onClick={startSprint}>
-                {t("review.reviewAgain", "Review more")}
-              </Button>
-              <Button onClick={() => navigate("/")}>{t("review.backToGame", "Back to game")}</Button>
-            </Stack>
-          </>
-        )}
-
-        {status === "active" && current && (
-          <>
-            <StatsRow stats={stats} t={t} />
-            <Typography variant="caption" color="text.secondary">
-              {index + 1} / {total}
-            </Typography>
-
-            <Card sx={{ width: "100%", textAlign: "center" }}>
-              <CardContent>
-                <Typography variant="overline" color="text.secondary">
-                  {promptLabel}
-                </Typography>
-                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5, my: 2 }}>
-                  <Typography variant="h4">{prompt}</Typography>
-                  {/* recognition: the prompt is the target-language word */}
-                  {ttsEnabled && !isProduction && (
-                    <ListenButton text={current.phrase} lang={current.target_lang} t={t} />
-                  )}
-                </Box>
-                {revealed && (
-                  <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5, mb: 1 }}>
-                    <Typography variant="h5" color="primary">
-                      {answer}
-                    </Typography>
-                    {/* production: the answer is the target-language word */}
-                    {ttsEnabled && isProduction && (
-                      <ListenButton text={current.phrase} lang={current.target_lang} t={t} />
-                    )}
-                  </Box>
-                )}
-              </CardContent>
-            </Card>
-
-            {!revealed ? (
-              <Button variant="contained" size="large" onClick={reveal} sx={{ minWidth: 200 }}>
-                {t("review.reveal", "Reveal")}
-              </Button>
-            ) : (
-              <Stack direction="row" spacing={1} sx={{ justifyContent: "center" }}>
-                <Button onClick={() => rate("again")} color="error" variant="outlined">
-                  ❌ {t("training.didntKnow", "Didn’t know")}
-                </Button>
-                <Button onClick={() => rate("good")} color="warning" variant="outlined">
-                  🤔 {t("training.shaky", "Shaky")}
-                </Button>
-                <Button onClick={() => rate("easy")} color="success" variant="contained">
-                  ✅ {t("training.knewIt", "Knew it")}
-                </Button>
-              </Stack>
-            )}
-            {ttsEnabled && current.target_lang && (
-              <Button size="small" startIcon={<RecordVoiceOverIcon />} onClick={() => setVoicesOpen(true)}>
-                {t("review.voices", "Voice packs")}
-              </Button>
-            )}
-            {backButton}
-          </>
-        )}
-      </Stack>
-
-        <VoiceManager
-          open={voicesOpen}
-          onClose={() => setVoicesOpen(false)}
-          lang={current?.target_lang}
-          sampleText={current?.phrase}
-          t={t}
-        />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, justifyContent: "center", mb: 2 }}>
+          <PsychologyIcon color="primary" />
+          <Typography variant="h5">{t("review.title", "Review sprint")}</Typography>
+        </Box>
+        <ReviewSprintPanel showBackToGame />
       </Container>
     </>
   );

--- a/frontend/src/features/game/components/Review/ReviewSprintPanel.jsx
+++ b/frontend/src/features/game/components/Review/ReviewSprintPanel.jsx
@@ -1,0 +1,173 @@
+import { Alert, Box, Button, Card, CardContent, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import RecordVoiceOverIcon from "@mui/icons-material/RecordVoiceOver";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { useReviewSprint } from "../../../../hooks/useReviewSprint";
+import { useSystemPreferences } from "../../../../hooks/useSystemPreferences";
+import ListenButton from "./ListenButton";
+import VoiceManager from "./VoiceManager";
+
+function StatsRow({ stats, t }) {
+  if (!stats) return null;
+  return (
+    <Stack direction="row" spacing={1} sx={{ justifyContent: "center", flexWrap: "wrap" }}>
+      {stats.streak > 0 && <Chip size="small" color="primary" label={`🔥 ${stats.streak}`} />}
+      <Chip size="small" label={`${t("review.tracked", "Tracked")}: ${stats.total ?? 0}`} />
+      <Chip size="small" color="warning" label={`${t("review.due", "Due")}: ${stats.due ?? 0}`} />
+      <Chip size="small" color="success" label={`${t("review.mastered", "Mastered")}: ${stats.mastered ?? 0}`} />
+    </Stack>
+  );
+}
+
+/**
+ * The review sprint flashcard flow (stats row, prompt card, reveal/rate), without any
+ * page chrome (header, container, back-to-game button). Used both by the full-page
+ * /review route and embedded directly in a dashboard tab (e.g. My Study).
+ */
+export default function ReviewSprintPanel({ showBackToGame = false }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [voicesOpen, setVoicesOpen] = useState(false);
+  const { ttsEnabled } = useSystemPreferences();
+  const { status, current, index, total, revealed, reveal, rate, stats, reviewedCount, startSprint } =
+    useReviewSprint();
+
+  const isProduction = current?.direction === "production";
+  // production: shown the meaning, recall the word. recognition: shown the word, recall the meaning.
+  const prompt = current ? (isProduction ? current.translation : current.phrase) : "";
+  const answer = current ? (isProduction ? current.phrase : current.translation) : "";
+  const promptLabel = isProduction
+    ? t("review.recallWord", "Recall the word")
+    : t("review.recallMeaning", "Recall the meaning");
+
+  const backButton = showBackToGame ? (
+    <Button onClick={() => navigate("/")} sx={{ alignSelf: "flex-start" }}>
+      {t("review.backToGame", "Back to game")}
+    </Button>
+  ) : null;
+
+  return (
+    <Stack spacing={2} sx={{ alignItems: "center" }}>
+      {status === "loading" && <CircularProgress sx={{ my: 4 }} />}
+
+      {status === "unauthenticated" && (
+        <>
+          <Alert severity="info" sx={{ width: "100%" }}>
+            {t("review.loginRequired", "Log in to review your words and track mastery.")}
+          </Alert>
+          <Button variant="contained" onClick={() => navigate("/admin")}>
+            {t("login", "Login")}
+          </Button>
+        </>
+      )}
+
+      {status === "error" && (
+        <>
+          <Typography color="error">{t("review.error", "Could not load your reviews.")}</Typography>
+          <Button variant="contained" onClick={startSprint}>
+            {t("review.retry", "Try again")}
+          </Button>
+          {backButton}
+        </>
+      )}
+
+      {status === "empty" && (
+        <>
+          <StatsRow stats={stats} t={t} />
+          <Typography sx={{ mt: 2 }}>{t("review.nothingDue", "Nothing due right now — come back later! 🎉")}</Typography>
+          {stats?.total > 0 && (
+            <Typography variant="body2" color="text.secondary" sx={{ textAlign: "center" }}>
+              {t(
+                "review.nothingDueExplainer",
+                "Words you rated well are scheduled further out so they resurface right when you're likely to start forgetting them — nothing is lost."
+              )}
+            </Typography>
+          )}
+          {backButton}
+        </>
+      )}
+
+      {status === "done" && (
+        <>
+          <StatsRow stats={stats} t={t} />
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            {t("review.sprintDone", "Sprint complete!")}
+          </Typography>
+          <Typography color="text.secondary">
+            {t("review.reviewedCount", "Reviewed {{count}} words", { count: reviewedCount })}
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            <Button variant="contained" onClick={startSprint}>
+              {t("review.reviewAgain", "Review more")}
+            </Button>
+            {backButton}
+          </Stack>
+        </>
+      )}
+
+      {status === "active" && current && (
+        <>
+          <StatsRow stats={stats} t={t} />
+          <Typography variant="caption" color="text.secondary">
+            {index + 1} / {total}
+          </Typography>
+
+          <Card sx={{ width: "100%", maxWidth: 480, textAlign: "center" }}>
+            <CardContent>
+              <Typography variant="overline" color="text.secondary">
+                {promptLabel}
+              </Typography>
+              <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5, my: 2 }}>
+                <Typography variant="h4">{prompt}</Typography>
+                {/* recognition: the prompt is the target-language word */}
+                {ttsEnabled && !isProduction && <ListenButton text={current.phrase} lang={current.target_lang} t={t} />}
+              </Box>
+              {revealed && (
+                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5, mb: 1 }}>
+                  <Typography variant="h5" color="primary">
+                    {answer}
+                  </Typography>
+                  {/* production: the answer is the target-language word */}
+                  {ttsEnabled && isProduction && <ListenButton text={current.phrase} lang={current.target_lang} t={t} />}
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+
+          {!revealed ? (
+            <Button variant="contained" size="large" onClick={reveal} sx={{ minWidth: 200 }}>
+              {t("review.reveal", "Reveal")}
+            </Button>
+          ) : (
+            <Stack direction="row" spacing={1} sx={{ justifyContent: "center" }}>
+              <Button onClick={() => rate("again")} color="error" variant="outlined">
+                ❌ {t("training.didntKnow", "Didn’t know")}
+              </Button>
+              <Button onClick={() => rate("good")} color="warning" variant="outlined">
+                🤔 {t("training.shaky", "Shaky")}
+              </Button>
+              <Button onClick={() => rate("easy")} color="success" variant="contained">
+                ✅ {t("training.knewIt", "Knew it")}
+              </Button>
+            </Stack>
+          )}
+          {ttsEnabled && current.target_lang && (
+            <Button size="small" startIcon={<RecordVoiceOverIcon />} onClick={() => setVoicesOpen(true)}>
+              {t("review.voices", "Voice packs")}
+            </Button>
+          )}
+          {backButton}
+        </>
+      )}
+
+      <VoiceManager
+        open={voicesOpen}
+        onClose={() => setVoicesOpen(false)}
+        lang={current?.target_lang}
+        sampleText={current?.phrase}
+        t={t}
+      />
+    </Stack>
+  );
+}

--- a/frontend/src/features/game/components/Review/__tests__/ReviewSprintPanel.test.jsx
+++ b/frontend/src/features/game/components/Review/__tests__/ReviewSprintPanel.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ReviewSprintPanel from '../ReviewSprintPanel';
+import { withI18n } from '../../../../../testUtils';
+
+jest.mock('../../../../../hooks/useSystemPreferences', () => ({
+    useSystemPreferences: () => ({ ttsEnabled: false }),
+}));
+
+jest.mock('../VoiceManager', () => () => <div data-testid="voice-manager" />);
+
+const mockUseReviewSprint = jest.fn();
+jest.mock('../../../../../hooks/useReviewSprint', () => ({
+    useReviewSprint: () => mockUseReviewSprint(),
+}));
+
+const renderPanel = (props) =>
+    render(withI18n(
+        <MemoryRouter>
+            <ReviewSprintPanel {...props} />
+        </MemoryRouter>
+    ));
+
+afterEach(() => {
+    mockUseReviewSprint.mockReset();
+});
+
+test('shows a loading spinner', () => {
+    mockUseReviewSprint.mockReturnValue({ status: 'loading' });
+    renderPanel();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+});
+
+test('empty state shows stats and an explainer when the user already has tracked words', () => {
+    mockUseReviewSprint.mockReturnValue({
+        status: 'empty',
+        stats: { total: 5, due: 0, mastered: 1, streak: 2 },
+        reviewedCount: 0,
+        startSprint: jest.fn(),
+    });
+    renderPanel();
+    expect(screen.getByText(/nothing due right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing is lost/i)).toBeInTheDocument();
+    expect(screen.getByText(/tracked: 5/i)).toBeInTheDocument();
+});
+
+test('empty state omits the explainer when nothing has ever been tracked', () => {
+    mockUseReviewSprint.mockReturnValue({
+        status: 'empty',
+        stats: { total: 0, due: 0, mastered: 0, streak: 0 },
+        reviewedCount: 0,
+        startSprint: jest.fn(),
+    });
+    renderPanel();
+    expect(screen.queryByText(/nothing is lost/i)).not.toBeInTheDocument();
+});
+
+test('active state reveals the answer and submits a rating', () => {
+    const rate = jest.fn();
+    const reveal = jest.fn();
+    mockUseReviewSprint.mockReturnValue({
+        status: 'active',
+        current: { phrase: 'kot', translation: 'cat', direction: 'recognition', target_lang: 'pl' },
+        index: 0,
+        total: 3,
+        revealed: false,
+        reveal,
+        rate,
+        stats: { total: 3, due: 3, mastered: 0, streak: 0 },
+    });
+    renderPanel();
+    expect(screen.getByText('kot')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /reveal/i }));
+    expect(reveal).toHaveBeenCalled();
+});
+
+test('active + revealed state shows the answer and rating buttons', () => {
+    const rate = jest.fn();
+    mockUseReviewSprint.mockReturnValue({
+        status: 'active',
+        current: { phrase: 'kot', translation: 'cat', direction: 'recognition', target_lang: 'pl' },
+        index: 0,
+        total: 3,
+        revealed: true,
+        reveal: jest.fn(),
+        rate,
+        stats: { total: 3, due: 3, mastered: 0, streak: 0 },
+    });
+    renderPanel();
+    expect(screen.getByText('cat')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /shaky/i }));
+    expect(rate).toHaveBeenCalledWith('good');
+});
+
+test('done state offers to review more', () => {
+    const startSprint = jest.fn();
+    mockUseReviewSprint.mockReturnValue({
+        status: 'done',
+        stats: { total: 5, due: 0, mastered: 2, streak: 1 },
+        reviewedCount: 5,
+        startSprint,
+    });
+    renderPanel();
+    expect(screen.getByText(/sprint complete/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /review more/i }));
+    expect(startSprint).toHaveBeenCalled();
+});
+
+test('showBackToGame renders a back-to-game button', () => {
+    mockUseReviewSprint.mockReturnValue({
+        status: 'done',
+        stats: { total: 1, due: 0, mastered: 0, streak: 0 },
+        reviewedCount: 1,
+        startSprint: jest.fn(),
+    });
+    renderPanel({ showBackToGame: true });
+    expect(screen.getByRole('button', { name: /back to game/i })).toBeInTheDocument();
+});
+
+test('omits the back-to-game button by default (embedded usage)', () => {
+    mockUseReviewSprint.mockReturnValue({
+        status: 'done',
+        stats: { total: 1, due: 0, mastered: 0, streak: 0 },
+        reviewedCount: 1,
+        startSprint: jest.fn(),
+    });
+    renderPanel();
+    expect(screen.queryByRole('button', { name: /back to game/i })).not.toBeInTheDocument();
+});

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -28,6 +28,7 @@
     "due": "Due",
     "mastered": "Mastered",
     "nothingDue": "Nothing due right now — come back later! 🎉",
+    "nothingDueExplainer": "Words you rated well are scheduled further out so they resurface right when you're likely to start forgetting them — nothing is lost.",
     "sprintDone": "Sprint complete!",
     "reviewedCount": "Reviewed {{count}} words",
     "reviewAgain": "Review more",

--- a/frontend/src/locales/hr.json
+++ b/frontend/src/locales/hr.json
@@ -28,6 +28,7 @@
     "due": "Za ponoviti",
     "mastered": "Savladano",
     "nothingDue": "Trenutno ništa za ponoviti — vratite se kasnije! 🎉",
+    "nothingDueExplainer": "Riječi koje ste dobro ocijenili planirane su za kasnije, kako bi se pojavile točno kad ih počnete zaboravljati — ništa nije izgubljeno.",
     "sprintDone": "Vježba završena!",
     "reviewedCount": "Ponovljeno riječi: {{count}}",
     "reviewAgain": "Ponovi još",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -28,6 +28,7 @@
     "due": "Do powtórki",
     "mastered": "Opanowane",
     "nothingDue": "Nic do powtórki — wróć później! 🎉",
+    "nothingDueExplainer": "Słowa, które dobrze oceniłeś, są zaplanowane na później, aby pojawiły się dokładnie wtedy, gdy zaczniesz je zapominać — nic nie ginie.",
     "sprintDone": "Sesja ukończona!",
     "reviewedCount": "Powtórzono słów: {{count}}",
     "reviewAgain": "Powtórz więcej",

--- a/helpers/e2e/README.md
+++ b/helpers/e2e/README.md
@@ -1,7 +1,8 @@
 # End-to-end smoke tests
 
 Playwright smoke tests that play the **regular path of both game modes** (word search +
-crossword) on **desktop and mobile** viewports, against a fully throwaway stack.
+crossword) on **desktop and mobile** viewports, against a fully throwaway stack. Also
+covers the demo-account login flow and the embedded Review Sprint tab in My Study.
 
 ## What runs
 
@@ -9,7 +10,9 @@ crossword) on **desktop and mobile** viewports, against a fully throwaway stack.
 
 1. A throwaway **Postgres** container (`docker`).
 2. The **backend** (from `backend/.venv`) serving the freshly-built frontend from
-   `backend/static` in production mode (`DEVELOPMENT_MODE=false`).
+   `backend/static` in production mode (`DEVELOPMENT_MODE=false`), with both an admin
+   account and a self-provisioned demo account (`DEMO_USERNAME`/`DEMO_PASSWORD_HASH` —
+   the same mechanism staging uses).
 3. **Seeds** one language set of overlapping short words via the admin API
    (`helpers/e2e/seed.py`) — enough for the crossword generator to find intersections and
    for the word-search grid.

--- a/helpers/e2e/run-e2e.sh
+++ b/helpers/e2e/run-e2e.sh
@@ -23,6 +23,8 @@ PG_NAME="osm-e2e-pg-$$"
 VENV="$ROOT/backend/.venv"
 ADMIN_USER="e2e-admin"
 ADMIN_PASS="e2e-pass-$$"
+DEMO_USER="e2e-demo"
+DEMO_PASS="e2e-demo-pass-$$"
 
 BACKEND_PID=""
 cleanup() {
@@ -75,8 +77,11 @@ echo "==> Building frontend and serving it from the backend"
 rm -rf "$ROOT/backend/static"
 cp -r "$ROOT/frontend/build" "$ROOT/backend/static"
 
-# Throwaway admin creds for this run (independent of any real credentials).
+# Throwaway admin + demo creds for this run (independent of any real credentials). The
+# demo account exercises the same self-provisioning path staging uses (DEMO_USERNAME /
+# DEMO_PASSWORD_HASH), so the e2e suite covers a regular-user login through the real form.
 ADMIN_HASH="$("$VENV/bin/python" -c "import bcrypt,sys; print(bcrypt.hashpw(sys.argv[1].encode(), bcrypt.gensalt()).decode())" "$ADMIN_PASS")"
+DEMO_HASH="$("$VENV/bin/python" -c "import bcrypt,sys; print(bcrypt.hashpw(sys.argv[1].encode(), bcrypt.gensalt()).decode())" "$DEMO_PASS")"
 
 echo "==> Starting backend on :$APP_PORT"
 (
@@ -84,6 +89,7 @@ echo "==> Starting backend on :$APP_PORT"
   POSTGRES_HOST=127.0.0.1 POSTGRES_PORT="$PG_PORT" POSTGRES_USER=postgres \
   POSTGRES_PASSWORD=postgres POSTGRES_DATABASE=osmosmjerka \
   ADMIN_USERNAME="$ADMIN_USER" ADMIN_PASSWORD_HASH="$ADMIN_HASH" ADMIN_SECRET_KEY="e2e-secret-$$" \
+  DEMO_USERNAME="$DEMO_USER" DEMO_PASSWORD_HASH="$DEMO_HASH" \
   DEVELOPMENT_MODE=false \
   exec "$VENV/bin/python" -m uvicorn osmosmjerka.app:app --host 127.0.0.1 --port "$APP_PORT"
 ) &
@@ -103,6 +109,7 @@ echo "==> Installing Playwright browser (firefox)"
 echo "==> Running Playwright specs (word search + crossword, desktop + mobile)"
 cd "$ROOT/frontend"
 E2E_BASE_URL="$BASE_URL" E2E_ADMIN_TOKEN="$E2E_ADMIN_TOKEN" E2E_LANG_SET_ID="$E2E_LANG_SET_ID" \
+  E2E_DEMO_USERNAME="$DEMO_USER" E2E_DEMO_PASSWORD="$DEMO_PASS" \
   npx playwright test --config e2e/playwright.config.js
 
 echo "==> E2E passed"


### PR DESCRIPTION
## Summary
- **Review Sprint tab**: extracted the flashcard/stats widget into `ReviewSprintPanel`, embedded as a third tab in My Study (alongside Assigned Puzzles / My Study Groups), reused by the existing full-page `/review` route too
- **SRS clarity**: added an explainer to the "nothing due" empty state — well-rated words are scheduled further out (not lost), which was correct but easy to misread as a bug
- **Demo account**: optional `DEMO_USERNAME`/`DEMO_PASSWORD_HASH` env vars self-provision a regular-user demo account on every startup, mirroring the existing root-admin bootstrap. Staging's DB gets wiped and re-cloned from prod on every deploy, so this makes the demo account self-healing across those clones instead of a one-off manual insert. No-op (and thus prod stays clean) unless both vars are set — the corresponding GitOps change (staging-only) is already live in `osmosmjerka-gitops`
- E2E: two new specs — demo account login through the real form as a non-privileged user, and the Review Sprint tab rendering in place without navigating away

## Test plan
- [x] Backend: 357 tests pass
- [x] Frontend: 425 tests pass
- [x] ruff check/format, eslint clean
- [x] Full local E2E suite (`helpers/e2e/run-e2e.sh`) green, 8/8 including the 2 new specs
- [x] Manually verified demo account create/refresh/no-op-in-prod against a live throwaway DB, and self-healing across a simulated DB wipe